### PR TITLE
Use the right collection, so accessing a non existent ContentType on a r...

### DIFF
--- a/src/Microsoft.AspNet.PipelineCore/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNet.PipelineCore/DefaultHttpResponse.cs
@@ -78,8 +78,8 @@ namespace Microsoft.AspNet.PipelineCore
         {
             get
             {
-                var contentTypeValues = HttpResponseInformation.Headers[Constants.Headers.ContentType];
-                return contentTypeValues.Length == 0 ? null : contentTypeValues[0];
+                var contentType = Headers[Constants.Headers.ContentType];
+                return contentType;
             }
             set
             {


### PR DESCRIPTION
...esponse doesn't throw and return null instead.

@loudej / @Tratcher  take a quick look
