### PR TITLE
Adding IServiceProvider interfaces to HttpContext

### DIFF
--- a/src/Microsoft.AspNet.Abstractions/HttpContext.cs
+++ b/src/Microsoft.AspNet.Abstractions/HttpContext.cs
@@ -11,6 +11,10 @@ namespace Microsoft.AspNet.Abstractions
         
         public abstract IDictionary<object, object> Items { get; }
 
+        public abstract IServiceProvider ApplicationServices { get; set; }
+
+        public abstract IServiceProvider RequestServices { get; set; }
+
         public abstract void Dispose();
 
         public abstract object GetFeature(Type type);

--- a/src/Microsoft.AspNet.PipelineCore/DefaultCanHasServiceProviders.cs
+++ b/src/Microsoft.AspNet.PipelineCore/DefaultCanHasServiceProviders.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Microsoft.AspNet.PipelineCore
+{
+    public class DefaultCanHasServiceProviders : ICanHasServiceProviders
+    {
+        public IServiceProvider ApplicationServices { get; set; }
+        public IServiceProvider RequestServices { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.PipelineCore/DefaultHttpContext.cs
+++ b/src/Microsoft.AspNet.PipelineCore/DefaultHttpContext.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNet.PipelineCore
         private readonly HttpResponse _response;
 
         private FeatureReference<ICanHasItems> _canHasItems;
+        private FeatureReference<ICanHasServiceProviders> _canHasServiceProviders;
         private IFeatureCollection _features;
 
         public DefaultHttpContext(IFeatureCollection features)
@@ -21,11 +22,17 @@ namespace Microsoft.AspNet.PipelineCore
             _response = new DefaultHttpResponse(this, features);
 
             _canHasItems = FeatureReference<ICanHasItems>.Default;
+            _canHasServiceProviders = FeatureReference<ICanHasServiceProviders>.Default;
         }
 
         ICanHasItems CanHasItems
         {
             get { return _canHasItems.Fetch(_features) ?? _canHasItems.Update(_features, new DefaultCanHasItems()); }
+        }
+
+        ICanHasServiceProviders CanHasServiceProviders
+        {
+            get { return _canHasServiceProviders.Fetch(_features) ?? _canHasServiceProviders.Update(_features, new DefaultCanHasServiceProviders()); }
         }
 
         public override HttpRequest Request { get { return _request; } }
@@ -35,6 +42,18 @@ namespace Microsoft.AspNet.PipelineCore
         public override IDictionary<object, object> Items
         {
             get { return CanHasItems.Items; }
+        }
+
+        public override IServiceProvider ApplicationServices
+        {
+            get { return CanHasServiceProviders.ApplicationServices; }
+            set { CanHasServiceProviders.ApplicationServices = value; }
+        }
+
+        public override IServiceProvider RequestServices
+        {
+            get { return CanHasServiceProviders.RequestServices; }
+            set { CanHasServiceProviders.RequestServices = value; }
         }
 
         public int Revision { get { return _features.Revision; } }

--- a/src/Microsoft.AspNet.PipelineCore/ICanHasServiceProviders.cs
+++ b/src/Microsoft.AspNet.PipelineCore/ICanHasServiceProviders.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Microsoft.AspNet.PipelineCore
+{
+    public interface ICanHasServiceProviders
+    {
+        IServiceProvider ApplicationServices { get; set; }
+        IServiceProvider RequestServices { get; set; }
+    }
+}


### PR DESCRIPTION
Adds top-level IServiceProvider properties to HttpContext. Adds a feature interface with a default implementation to hold values.
