### PR TITLE
Change Challenge, SignIn parameter order to support params.

### DIFF
--- a/src/Microsoft.AspNet.Http/HttpResponse.cs
+++ b/src/Microsoft.AspNet.Http/HttpResponse.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Http
 
         public virtual void Challenge(AuthenticationProperties properties)
         {
-            Challenge(new string[0], properties);
+            Challenge(properties, new string[0]);
         }
 
         public virtual void Challenge(string authenticationType)
@@ -48,34 +48,54 @@ namespace Microsoft.AspNet.Http
             Challenge(new[] { authenticationType });
         }
 
-        public virtual void Challenge(string authenticationType, AuthenticationProperties properties)
+        public virtual void Challenge(AuthenticationProperties properties, string authenticationType)
         {
-            Challenge(new[] { authenticationType }, properties);
+            Challenge(properties, new[] { authenticationType });
+        }
+
+        public void Challenge(params string[] authenticationTypes)
+        {
+            Challenge((IEnumerable<string>)authenticationTypes);
         }
 
         public virtual void Challenge(IEnumerable<string> authenticationTypes)
         {
-            Challenge(authenticationTypes, properties: null);
+            Challenge(properties: null, authenticationTypes:  authenticationTypes);
         }
 
-        public abstract void Challenge(IEnumerable<string> authenticationTypes, AuthenticationProperties properties);
+        public void Challenge(AuthenticationProperties properties, params string[] authenticationTypes)
+        {
+            Challenge(properties, (IEnumerable<string>)authenticationTypes);
+        }
+
+        public abstract void Challenge(AuthenticationProperties properties, IEnumerable<string> authenticationTypes);
 
         public virtual void SignIn(ClaimsIdentity identity)
         {
-            SignIn(identity, properties: null);
+            SignIn(properties: null, identity: identity);
         }
 
-        public virtual void SignIn(ClaimsIdentity identity, AuthenticationProperties properties)
+        public virtual void SignIn(AuthenticationProperties properties, ClaimsIdentity identity)
         {
-            SignIn(new[] { identity }, properties);
+            SignIn(properties, new[] { identity });
+        }
+
+        public virtual void SignIn(params ClaimsIdentity[] identities)
+        {
+            SignIn(properties: null, identities: (IEnumerable<ClaimsIdentity>)identities);
         }
 
         public virtual void SignIn(IEnumerable<ClaimsIdentity> identities)
         {
-            SignIn(identities, properties: null);
+            SignIn(properties: null, identities: identities);
         }
 
-        public abstract void SignIn(IEnumerable<ClaimsIdentity> identities, AuthenticationProperties properties);
+        public void SignIn(AuthenticationProperties properties, params ClaimsIdentity[] identities)
+        {
+            SignIn(properties, (IEnumerable<ClaimsIdentity>)identities);
+        }
+
+        public abstract void SignIn(AuthenticationProperties properties, IEnumerable<ClaimsIdentity> identities);
 
         public virtual void SignOut()
         {

--- a/src/Microsoft.AspNet.PipelineCore/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNet.PipelineCore/DefaultHttpResponse.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNet.PipelineCore
             Headers.Set(Constants.Headers.Location, location);
         }
 
-        public override void Challenge(IEnumerable<string> authenticationTypes, AuthenticationProperties properties)
+        public override void Challenge(AuthenticationProperties properties, IEnumerable<string> authenticationTypes)
         {
             if (authenticationTypes == null)
             {
@@ -147,12 +147,13 @@ namespace Microsoft.AspNet.PipelineCore
             }
         }
 
-        public override void SignIn(IEnumerable<ClaimsIdentity> identities, AuthenticationProperties properties)
+        public override void SignIn(AuthenticationProperties properties, IEnumerable<ClaimsIdentity> identities)
         {
             if (identities == null)
             {
                 throw new ArgumentNullException();
             }
+
             var handler = HttpAuthenticationFeature.Handler;
 
             var signInContext = new SignInContext(identities, properties == null ? null : properties.Dictionary);


### PR DESCRIPTION
#111

If we get support for `params IEnumerable<T>` then we can remove some of these overloads.
