### PR TITLE
Remove semi-colon support from query parsing.

### DIFF
--- a/src/Microsoft.AspNet.WebUtilities/ParsingHelpers.cs
+++ b/src/Microsoft.AspNet.WebUtilities/ParsingHelpers.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.WebUtilities
         {
             IDictionary<string, string[]> form = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
             var accumulator = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-            ParseDelimited(text, new[] { '&' }, AppendItemCallback, accumulator);
+            ParseDelimited(text, Ampersand, AppendItemCallback, accumulator);
             foreach (var kv in accumulator)
             {
                 form.Add(kv.Key, kv.Value.ToArray());
@@ -92,7 +92,7 @@ namespace Microsoft.AspNet.WebUtilities
             return store.TryGetValue(key, out values) ? values : null;
         }
 
-        private static readonly char[] AmpersandAndSemicolon = new[] { '&', ';' };
+        private static readonly char[] Ampersand = new[] { '&' };
 
         internal static IReadableStringCollection GetQuery(string queryString)
         {
@@ -101,7 +101,7 @@ namespace Microsoft.AspNet.WebUtilities
                 queryString = queryString.Substring(1);
             }
             var accumulator = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-            ParseDelimited(queryString, AmpersandAndSemicolon, AppendItemCallback, accumulator);
+            ParseDelimited(queryString, Ampersand, AppendItemCallback, accumulator);
             return new ReadableStringCollection(accumulator.ToDictionary(
                     item => item.Key,
                     item => item.Value.ToArray(),

--- a/test/Microsoft.AspNet.WebUtilities.Tests/QueryHelpersTests.cs
+++ b/test/Microsoft.AspNet.WebUtilities.Tests/QueryHelpersTests.cs
@@ -36,18 +36,9 @@ namespace Microsoft.AspNet.WebUtilities
         }
 
         [Fact]
-        public void ParseQueryWithSemicolonWorks()
-        {
-            var collection = QueryHelpers.ParseQuery("?key1=value1;key2=value2");
-            Assert.Equal(2, collection.Count);
-            Assert.Equal("value1", collection["key1"]);
-            Assert.Equal("value2", collection["key2"]);
-        }
-
-        [Fact]
         public void ParseQueryWithEmptyValuesWorks()
         {
-            var collection = QueryHelpers.ParseQuery("?key1=;key2=");
+            var collection = QueryHelpers.ParseQuery("?key1=&key2=");
             Assert.Equal(2, collection.Count);
             Assert.Equal(string.Empty, collection["key1"]);
             Assert.Equal(string.Empty, collection["key2"]);
@@ -56,7 +47,7 @@ namespace Microsoft.AspNet.WebUtilities
         [Fact]
         public void ParseQueryWithEmptyKeyWorks()
         {
-            var collection = QueryHelpers.ParseQuery("?=value1;=");
+            var collection = QueryHelpers.ParseQuery("?=value1&=");
             Assert.Equal(1, collection.Count);
             Assert.Equal("value1,", collection[""]);
         }


### PR DESCRIPTION
#130 @Eilon

Semicolons are non-standard and not in common usage.
