### PR TITLE
Optimized performance of TryStringToDate via short-circuiting

### DIFF
--- a/src/Microsoft.Net.Http.Headers/HttpRuleParser.cs
+++ b/src/Microsoft.Net.Http.Headers/HttpRuleParser.cs
@@ -89,6 +89,10 @@ namespace Microsoft.Net.Http.Headers
                     DateFormatsMaxLength = dateFormat.Length;
                 }
             }
+            
+            // DateTime formats: H, m, s, and d could all be 2 digits, so add one for each. 
+            // zzz can be 6 digits, so add 3
+            DateFormatsMaxLength += 7;
         }
 
         internal static bool IsTokenChar(char character)


### PR DESCRIPTION
Note that I did this without an IDE, but I'm 99% sure it compiles. ;)

Basically this will allow less work to be done if the input *clearly* does not conform to any known date length.

The max length has to be expanded by `7`. +1 per `H`, `m`, `s`, and `d` char and +3 for `zzz`.

`H` can be `0` to `23`
`m` can be `0` to `59`
`s` can be `0` to `59`
`d` can be `1` to `31`
`zzz` can be a lot of things, but at largest `+05:00` or `-05:00` type values