### PR TITLE
Rename HttpRequest.IsSecure -> HttpRequest.IsHttps

### DIFF
--- a/src/Microsoft.AspNet.Http.Core/DefaultHttpRequest.cs
+++ b/src/Microsoft.AspNet.Http.Core/DefaultHttpRequest.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNet.Http.Core
             set { HttpRequestFeature.Scheme = value; }
         }
 
-        public override bool IsSecure
+        public override bool IsHttps
         {
             get { return string.Equals("https", Scheme, StringComparison.OrdinalIgnoreCase); }
         }

--- a/src/Microsoft.AspNet.Http/HttpRequest.cs
+++ b/src/Microsoft.AspNet.Http/HttpRequest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Http
         /// Returns true if the owin.RequestScheme is https.
         /// </summary>
         /// <returns>true if this request is using https; otherwise, false.</returns>
-        public abstract bool IsSecure { get; }
+        public abstract bool IsHttps { get; }
 
         /// <summary>
         /// Gets or set the Host header. May include the port.

--- a/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
+++ b/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNet.Owin
                 _context.Items[OwinConstants.OwinVersion] = "1.0";
             }
 
-            if (context.Request.IsSecure)
+            if (context.Request.IsHttps)
             {
                 _entries.Add(OwinConstants.CommonKeys.ClientCertificate, new FeatureMap<IHttpClientCertificateFeature>(feature => feature.ClientCertificate,
                     (feature, value) => feature.ClientCertificate = (X509Certificate)value));


### PR DESCRIPTION
Fixes https://github.com/aspnet/HttpAbstractions/issues/179
/cc @blowdart @Tratcher 