### PR TITLE
Replace WebSocket dependency. Remove chained dependencies.

### DIFF
--- a/src/Microsoft.AspNet.Http.Core/project.json
+++ b/src/Microsoft.AspNet.Http.Core/project.json
@@ -14,21 +14,8 @@
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
-                "Microsoft.Net.WebSocketAbstractions": "1.0.0-*",
-                "System.Collections": "4.0.10-beta-*",
-                "System.ComponentModel": "4.0.0-beta-*",
                 "System.Diagnostics.Debug": "4.0.10-beta-*",
-                "System.Diagnostics.Tools": "4.0.0-beta-*",
-                "System.Globalization": "4.0.10-beta-*",
-                "System.IO": "4.0.10-beta-*",
-                "System.Linq": "4.0.0-beta-*",
-                "System.Runtime": "4.0.20-beta-*",
-                "System.Runtime.Extensions": "4.0.10-beta-*",
-                "System.Runtime.InteropServices": "4.0.20-beta-*",
-                "System.Security.Claims": "4.0.0-beta-*",
-                "System.Security.Principal": "4.0.0-beta-*",
-                "System.Text.Encoding": "4.0.10-beta-*",
-                "System.Threading.Tasks": "4.0.10-beta-*"
+                "System.Text.Encoding": "4.0.10-beta-*"
             }
         }
     }

--- a/src/Microsoft.AspNet.Http.Interfaces/project.json
+++ b/src/Microsoft.AspNet.Http.Interfaces/project.json
@@ -5,8 +5,8 @@
     "dnx451": {},
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.Net.WebSocketAbstractions": "1.0.0-*",
         "System.Net.Primitives": "4.0.10-beta-*",
+        "System.Net.WebSockets" : "4.0.0-beta-*",
         "System.Security.Claims": "4.0.0-beta-*",
         "System.Security.Cryptography.X509Certificates": "4.0.0-beta-*",
         "System.Security.Principal": "4.0.0-beta-*"

--- a/src/Microsoft.AspNet.Http/project.json
+++ b/src/Microsoft.AspNet.Http/project.json
@@ -9,16 +9,13 @@
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
-                "Microsoft.Net.WebSocketAbstractions": "1.0.0-*",
                 "System.Collections": "4.0.10-beta-*",
-                "System.ComponentModel": "4.0.0-beta-*",
                 "System.Diagnostics.Tools": "4.0.0-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.Globalization.Extensions": "4.0.0-beta-*",
-                "System.IO": "4.0.10-beta-*",
                 "System.Linq": "4.0.0-beta-*",
+                "System.Net.WebSockets" : "4.0.0-beta-*",
                 "System.Runtime": "4.0.20-beta-*",
-                "System.Runtime.Extensions": "4.0.10-beta-*",
                 "System.Runtime.InteropServices": "4.0.20-beta-*",
                 "System.Security.Claims": "4.0.0-beta-*",
                 "System.Security.Principal": "4.0.0-beta-*",


### PR DESCRIPTION
Microsoft.Net.WebSocketAbstractions can now be replaced with System.Net.WebSockets.

@davidfowl @Eilon 