### PR TITLE
Simplify Challenge flow

### DIFF
--- a/src/Microsoft.AspNet.Http.Core/Authentication/ChallengeContext.cs
+++ b/src/Microsoft.AspNet.Http.Core/Authentication/ChallengeContext.cs
@@ -4,33 +4,34 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.Http.Authentication;
-using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Http.Core.Authentication
 {
     public class ChallengeContext : IChallengeContext
     {
-        private List<string> _accepted;
+        private bool _accepted;
 
-        public ChallengeContext([NotNull] IEnumerable<string> authenticationSchemes, IDictionary<string, string> properties)
+        public ChallengeContext(string authenticationScheme, IDictionary<string, string> properties)
         {
-            AuthenticationSchemes = authenticationSchemes;
+            AuthenticationScheme = authenticationScheme;
             Properties = properties ?? new Dictionary<string, string>(StringComparer.Ordinal);
-            _accepted = new List<string>();
+
+            // The default Challenge with no scheme is always accepted
+            _accepted = string.IsNullOrEmpty(authenticationScheme);
         }
 
-        public IEnumerable<string> AuthenticationSchemes { get; private set; }
+        public string AuthenticationScheme { get; private set; }
 
         public IDictionary<string, string> Properties { get; private set; }
 
-        public IEnumerable<string> Accepted
+        public bool Accepted
         {
             get { return _accepted; }
         }
 
-        public void Accept(string authenticationType, IDictionary<string, object> description)
+        public void Accept()
         {
-            _accepted.Add(authenticationType);
+            _accepted = true;
         }
     }
 }

--- a/src/Microsoft.AspNet.Http.Core/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNet.Http.Core/DefaultHttpResponse.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNet.Http.Core
             Headers.Set(Constants.Headers.Location, location);
         }
 
-        public override void Challenge(AuthenticationProperties properties, [NotNull] string authenticationScheme)
+        public override void Challenge(AuthenticationProperties properties, string authenticationScheme)
         {
             HttpResponseFeature.StatusCode = 401;
             var handler = HttpAuthenticationFeature.Handler;

--- a/src/Microsoft.AspNet.Http.Core/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNet.Http.Core/DefaultHttpResponse.cs
@@ -130,22 +130,20 @@ namespace Microsoft.AspNet.Http.Core
             Headers.Set(Constants.Headers.Location, location);
         }
 
-        public override void Challenge(AuthenticationProperties properties, [NotNull] IEnumerable<string> authenticationSchemes)
+        public override void Challenge(AuthenticationProperties properties, [NotNull] string authenticationScheme)
         {
             HttpResponseFeature.StatusCode = 401;
             var handler = HttpAuthenticationFeature.Handler;
 
-            var challengeContext = new ChallengeContext(authenticationSchemes, properties == null ? null : properties.Dictionary);
+            var challengeContext = new ChallengeContext(authenticationScheme, properties == null ? null : properties.Dictionary);
             if (handler != null)
             {
                 handler.Challenge(challengeContext);
             }
 
-            // Verify all types ack'd
-            IEnumerable<string> leftovers = authenticationSchemes.Except(challengeContext.Accepted);
-            if (leftovers.Any())
+            if (!challengeContext.Accepted)
             {
-                throw new InvalidOperationException("The following authentication types were not accepted: " + string.Join(", ", leftovers));
+                throw new InvalidOperationException("The following authentication type was not accepted: " + authenticationScheme);
             }
         }
 

--- a/src/Microsoft.AspNet.Http.Interfaces/Authentication/IChallengeContext.cs
+++ b/src/Microsoft.AspNet.Http.Interfaces/Authentication/IChallengeContext.cs
@@ -7,9 +7,9 @@ namespace Microsoft.AspNet.Http.Authentication
 {
     public interface IChallengeContext
     {
-        IEnumerable<string> AuthenticationSchemes {get;}
-        IDictionary<string,string> Properties {get;}
+        string AuthenticationScheme { get; }
+        IDictionary<string, string> Properties { get; }
 
-        void Accept(string authenticationType, IDictionary<string,object> description);
+        void Accept();
     }
 }

--- a/src/Microsoft.AspNet.Http/HttpResponse.cs
+++ b/src/Microsoft.AspNet.Http/HttpResponse.cs
@@ -51,24 +51,6 @@ namespace Microsoft.AspNet.Http
             Challenge(properties: null, authenticationScheme: authenticationScheme);
         }
 
-        public virtual void Challenge(params string[] authenticationSchemes)
-        {
-            Challenge(properties: null, authenticationSchemes: authenticationSchemes);
-        }
-
-        public virtual void Challenge(IEnumerable<string> authenticationSchemes)
-        {
-            Challenge(properties: null, authenticationSchemes: authenticationSchemes);
-        }
-
-        public virtual void Challenge(AuthenticationProperties properties, IEnumerable<string> authenticationSchemes)
-        {
-            foreach (var scheme in authenticationSchemes)
-            {
-                Challenge(properties, scheme);
-            }
-        }
-
         public abstract void Challenge(AuthenticationProperties properties, string authenticationScheme);
 
         public abstract void SignIn(string authenticationScheme, ClaimsPrincipal principal, AuthenticationProperties properties = null);

--- a/src/Microsoft.AspNet.Http/HttpResponse.cs
+++ b/src/Microsoft.AspNet.Http/HttpResponse.cs
@@ -38,27 +38,22 @@ namespace Microsoft.AspNet.Http
 
         public virtual void Challenge()
         {
-            Challenge(new string[0]);
+            Challenge(properties: null, authenticationScheme: null);
         }
 
         public virtual void Challenge(AuthenticationProperties properties)
         {
-            Challenge(properties, new string[0]);
+            Challenge(properties, "");
         }
 
         public virtual void Challenge(string authenticationScheme)
         {
-            Challenge(new[] { authenticationScheme });
-        }
-
-        public virtual void Challenge(AuthenticationProperties properties, string authenticationScheme)
-        {
-            Challenge(properties, new[] { authenticationScheme });
+            Challenge(properties: null, authenticationScheme: authenticationScheme);
         }
 
         public virtual void Challenge(params string[] authenticationSchemes)
         {
-            Challenge((IEnumerable<string>)authenticationSchemes);
+            Challenge(properties: null, authenticationSchemes: authenticationSchemes);
         }
 
         public virtual void Challenge(IEnumerable<string> authenticationSchemes)
@@ -66,12 +61,15 @@ namespace Microsoft.AspNet.Http
             Challenge(properties: null, authenticationSchemes: authenticationSchemes);
         }
 
-        public virtual void Challenge(AuthenticationProperties properties, params string[] authenticationSchemes)
+        public virtual void Challenge(AuthenticationProperties properties, IEnumerable<string> authenticationSchemes)
         {
-            Challenge(properties, (IEnumerable<string>)authenticationSchemes);
+            foreach (var scheme in authenticationSchemes)
+            {
+                Challenge(properties, scheme);
+            }
         }
 
-        public abstract void Challenge(AuthenticationProperties properties, IEnumerable<string> authenticationSchemes);
+        public abstract void Challenge(AuthenticationProperties properties, string authenticationScheme);
 
         public abstract void SignIn(string authenticationScheme, ClaimsPrincipal principal, AuthenticationProperties properties = null);
 


### PR DESCRIPTION
Sugar overloads still allow challenging multiple schemes, but each
ChallengeContext is only dealing with one scheme at a time

cc @Tratcher @lodejard 