### PR TITLE
Update cookie APIs to use shared core

### DIFF
--- a/src/Microsoft.AspNet.Http.Core/Collections/ResponseCookies.cs
+++ b/src/Microsoft.AspNet.Http.Core/Collections/ResponseCookies.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Microsoft.AspNet.Http.Infrastructure;
 using Microsoft.Framework.Internal;
 using Microsoft.Framework.WebEncoders;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Core.Collections
 {
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.Http.Core.Collections
         /// <param name="value"></param>
         public void Append(string key, string value)
         {
-            Headers.AppendValues(Constants.Headers.SetCookie, UrlEncoder.Default.UrlEncode(key) + "=" + UrlEncoder.Default.UrlEncode(value) + "; path=/");
+            Headers.AppendValues(HeaderNames.SetCookie, UrlEncoder.Default.UrlEncode(key) + "=" + UrlEncoder.Default.UrlEncode(value) + "; path=/");
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Http.Core.Collections
                 !expiresHasValue ? null : options.Expires.Value.ToString("ddd, dd-MMM-yyyy HH:mm:ss ", CultureInfo.InvariantCulture) + "GMT",
                 !options.Secure ? null : "; secure",
                 !options.HttpOnly ? null : "; HttpOnly");
-            Headers.AppendValues("Set-Cookie", setCookieValue);
+            Headers.AppendValues(HeaderNames.SetCookie, setCookieValue);
         }
 
         /// <summary>
@@ -73,14 +73,14 @@ namespace Microsoft.AspNet.Http.Core.Collections
             Func<string, bool> predicate = value => value.StartsWith(key + "=", StringComparison.OrdinalIgnoreCase);
 
             var deleteCookies = new[] { UrlEncoder.Default.UrlEncode(key) + "=; expires=Thu, 01-Jan-1970 00:00:00 GMT" };
-            IList<string> existingValues = Headers.GetValues(Constants.Headers.SetCookie);
+            IList<string> existingValues = Headers.GetValues(HeaderNames.SetCookie);
             if (existingValues == null || existingValues.Count == 0)
             {
-                Headers.SetValues(Constants.Headers.SetCookie, deleteCookies);
+                Headers.SetValues(HeaderNames.SetCookie, deleteCookies);
             }
             else
             {
-                Headers.SetValues(Constants.Headers.SetCookie, existingValues.Where(value => !predicate(value)).Concat(deleteCookies).ToArray());
+                Headers.SetValues(HeaderNames.SetCookie, existingValues.Where(value => !predicate(value)).Concat(deleteCookies).ToArray());
             }
         }
 
@@ -112,10 +112,10 @@ namespace Microsoft.AspNet.Http.Core.Collections
                 rejectPredicate = value => value.StartsWith(key + "=", StringComparison.OrdinalIgnoreCase);
             }
 
-            IList<string> existingValues = Headers.GetValues(Constants.Headers.SetCookie);
+            IList<string> existingValues = Headers.GetValues(HeaderNames.SetCookie);
             if (existingValues != null)
             {
-                Headers.SetValues(Constants.Headers.SetCookie, existingValues.Where(value => !rejectPredicate(value)).ToArray());
+                Headers.SetValues(HeaderNames.SetCookie, existingValues.Where(value => !rejectPredicate(value)).ToArray());
             }
 
             Append(key, string.Empty, new CookieOptions

--- a/src/Microsoft.AspNet.Http.Core/DefaultHttpContext.cs
+++ b/src/Microsoft.AspNet.Http.Core/DefaultHttpContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.WebSockets;
 using System.Security.Claims;
 using System.Threading;
@@ -13,8 +12,8 @@ using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.Http.Core.Authentication;
 using Microsoft.AspNet.Http.Core.Collections;
 using Microsoft.AspNet.Http.Core.Infrastructure;
-using Microsoft.AspNet.Http.Infrastructure;
 using Microsoft.Framework.Internal;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Core
 {
@@ -169,7 +168,7 @@ namespace Microsoft.AspNet.Http.Core
         {
             get
             {
-                return Request.Headers.GetValues(Constants.Headers.WebSocketSubProtocols) ?? EmptyList;
+                return Request.Headers.GetValues(HeaderNames.WebSocketSubProtocols) ?? EmptyList;
             }
         }
 

--- a/src/Microsoft.AspNet.Http.Core/DefaultHttpRequest.cs
+++ b/src/Microsoft.AspNet.Http.Core/DefaultHttpRequest.cs
@@ -6,10 +6,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.FeatureModel;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Http.Infrastructure;
 using Microsoft.AspNet.Http.Core.Collections;
 using Microsoft.AspNet.Http.Core.Infrastructure;
+using Microsoft.AspNet.Http.Infrastructure;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Core
 {
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.Http.Core
 
         public override bool IsHttps
         {
-            get { return string.Equals("https", Scheme, StringComparison.OrdinalIgnoreCase); }
+            get { return string.Equals(Constants.Https, Scheme, StringComparison.OrdinalIgnoreCase); }
         }
 
         public override HostString Host
@@ -145,8 +145,8 @@ namespace Microsoft.AspNet.Http.Core
 
         public override string ContentType
         {
-            get { return Headers[Constants.Headers.ContentType]; }
-            set { Headers[Constants.Headers.ContentType] = value; }
+            get { return Headers[HeaderNames.ContentType]; }
+            set { Headers[HeaderNames.ContentType] = value; }
         }
 
         public override bool HasFormContentType

--- a/src/Microsoft.AspNet.Http.Core/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNet.Http.Core/DefaultHttpResponse.cs
@@ -11,8 +11,8 @@ using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.Http.Core.Authentication;
 using Microsoft.AspNet.Http.Core.Collections;
 using Microsoft.AspNet.Http.Core.Infrastructure;
-using Microsoft.AspNet.Http.Infrastructure;
 using Microsoft.Framework.Internal;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Core
 {
@@ -80,18 +80,18 @@ namespace Microsoft.AspNet.Http.Core
         {
             get
             {
-                var contentType = Headers[Constants.Headers.ContentType];
+                var contentType = Headers[HeaderNames.ContentType];
                 return contentType;
             }
             set
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    HttpResponseFeature.Headers.Remove(Constants.Headers.ContentType);
+                    HttpResponseFeature.Headers.Remove(HeaderNames.ContentType);
                 }
                 else
                 {
-                    HttpResponseFeature.Headers[Constants.Headers.ContentType] = new[] { value };
+                    HttpResponseFeature.Headers[HeaderNames.ContentType] = new[] { value };
                 }
             }
         }
@@ -127,7 +127,7 @@ namespace Microsoft.AspNet.Http.Core
                 HttpResponseFeature.StatusCode = 302;
             }
 
-            Headers.Set(Constants.Headers.Location, location);
+            Headers.Set(HeaderNames.Location, location);
         }
 
         public override void Challenge(AuthenticationProperties properties, [NotNull] IEnumerable<string> authenticationSchemes)

--- a/src/Microsoft.AspNet.Http.Core/Infrastructure/Constants.cs
+++ b/src/Microsoft.AspNet.Http.Core/Infrastructure/Constants.cs
@@ -7,25 +7,6 @@ namespace Microsoft.AspNet.Http.Infrastructure
     {
         internal const string Https = "HTTPS";
 
-        internal const string HttpDateFormat = "r";
-
-        internal static class Headers
-        {
-            internal const string ContentType = "Content-Type";
-            internal const string CacheControl = "Cache-Control";
-            internal const string MediaType = "Media-Type";
-            internal const string Accept = "Accept";
-            internal const string AcceptCharset = "Accept-Charset";
-            internal const string Host = "Host";
-            internal const string ETag = "ETag";
-            internal const string Location = "Location";
-            internal const string ContentLength = "Content-Length";
-            internal const string Cookie = "Cookie";
-            internal const string SetCookie = "Set-Cookie";
-            internal const string Expires = "Expires";
-            internal const string WebSocketSubProtocols = "Sec-WebSocket-Protocol";
-        }
-
         internal static class BuilderProperties
         {
             internal static string ServerInformation = "server.Information";

--- a/src/Microsoft.AspNet.Http.Core/Infrastructure/ParsingHelpers.cs
+++ b/src/Microsoft.AspNet.Http.Core/Infrastructure/ParsingHelpers.cs
@@ -6,8 +6,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Microsoft.AspNet.Http.Infrastructure;
 using Microsoft.Framework.Internal;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Core.Infrastructure
 {
@@ -775,7 +775,7 @@ namespace Microsoft.AspNet.Http.Core.Infrastructure
         {
             const NumberStyles styles = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
             long value;
-            string rawValue = headers.Get(Constants.Headers.ContentLength);
+            string rawValue = headers.Get(HeaderNames.ContentLength);
             if (!string.IsNullOrWhiteSpace(rawValue) &&
                 long.TryParse(rawValue, styles, CultureInfo.InvariantCulture, out value))
             {
@@ -789,11 +789,11 @@ namespace Microsoft.AspNet.Http.Core.Infrastructure
         {
             if (value.HasValue)
             {
-                headers[Constants.Headers.ContentLength] = value.Value.ToString(CultureInfo.InvariantCulture);
+                headers[HeaderNames.ContentLength] = value.Value.ToString(CultureInfo.InvariantCulture);
             }
             else
             {
-                headers.Remove(Constants.Headers.ContentLength);
+                headers.Remove(HeaderNames.ContentLength);
             }
         }
     }

--- a/src/Microsoft.AspNet.Http.Core/RequestCookiesFeature.cs
+++ b/src/Microsoft.AspNet.Http.Core/RequestCookiesFeature.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using Microsoft.AspNet.FeatureModel;
 using Microsoft.AspNet.Http.Core.Collections;
 using Microsoft.AspNet.Http.Core.Infrastructure;
-using Microsoft.AspNet.Http.Infrastructure;
 using Microsoft.Framework.Internal;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Core
 {
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.Http.Core
                 }
 
                 var headers = _request.Fetch(_features).Headers;
-                string cookiesHeader = ParsingHelpers.GetHeader(headers, Constants.Headers.Cookie) ?? string.Empty;
+                string cookiesHeader = ParsingHelpers.GetHeader(headers, HeaderNames.Cookie) ?? string.Empty;
 
                 if (_cookiesCollection == null)
                 {

--- a/src/Microsoft.Net.Http.Headers/HeaderNames.cs
+++ b/src/Microsoft.Net.Http.Headers/HeaderNames.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Net.Http.Headers
         public const string Vary = "Vary";
         public const string Via = "Via";
         public const string Warning = "Warning";
+        public const string WebSocketSubProtocols = "Sec-WebSocket-Protocol";
         public const string WWWAuthenticate = "WWW-Authenticate";
     }
 }


### PR DESCRIPTION
#167 
We added the CookieHeaderValue and SetCookieHeaderValue types a while ago, but had not yet taken advantage of them in our cookie APIs. This now consumes them internally without affecting any public APIs.