### PR TITLE
Spelling mistake.

### DIFF
--- a/src/Microsoft.AspNet.Http.Core/FormFeature.cs
+++ b/src/Microsoft.AspNet.Http.Core/FormFeature.cs
@@ -48,8 +48,8 @@ namespace Microsoft.AspNet.Http.Core
                     return true;
                 }
 
-                var conentType = ContentType;
-                return HasApplicationFormContentType(conentType) || HasMultipartFormContentType(conentType);
+                var contentType = ContentType;
+                return HasApplicationFormContentType(contentType) || HasMultipartFormContentType(contentType);
             }
         }
 


### PR DESCRIPTION
Sorry I was looking at this code trying to track down a bug somewhere else and noticed a spelling mistake for a local variable. I know I tend to be anal about spelling, so figured I'd at least point it out.