### PR TITLE
Support Set<T> & Get<T> in ISessionCollection

### DIFF
--- a/src/Microsoft.AspNet.Http.Extensions/SessionExtensions.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/SessionExtensions.cs
@@ -51,5 +51,20 @@ namespace Microsoft.AspNet.Http
             session.TryGetValue(key, out value);
             return value;
         }
+
+        public static void Set(this ISessionCollection session, string key, byte[] value)
+        {
+            session.Set(key, new ArraySegment<byte>(value));
+        }
+        
+        public static T Get<T>(this ISessionCollection session, string key, ISessionFormatter<T> formatter)
+        {
+            return formatter.Deserialize(session.Get(key));
+        }
+
+        public static void Set<T>(this ISessionCollection session, string key, T value, ISessionFormatter<T> formatter)
+        {
+            session.Set(key, formatter.Serialize(value));
+        }
     }
 }

--- a/src/Microsoft.AspNet.Http.Interfaces/ISessionFormatter.cs
+++ b/src/Microsoft.AspNet.Http.Interfaces/ISessionFormatter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Http
+{
+    /// <summary>
+    /// Provides functionality for formatting serialized objects.
+    /// </summary>
+    public interface ISessionFormatter<T>
+    {
+        /// <summary>
+        /// Serializes an object.
+        /// </summary>
+        /// <returns>The serialized data</returns>
+        byte[] Serialize(T value);
+
+        /// <summary>
+        /// Deserializes the data and reconstitutes the object.
+        /// </summary>
+        /// <returns>The object of the deserialized data.</returns>
+        T Deserialize(byte[] data);
+    }
+}


### PR DESCRIPTION
Provide a generic version of ```ISessionCollection.Set<T>``` and ```ISessionCollection.Get<T>``` which allow the developers to implement ```ISessionFormatter```. Based on David Fowler suggestion we can plug ```BondSessionFormatter``` or ```ProtoBufSessionFormatter``` as well.
/cc @Tratcher