### PR TITLE
Move UseMiddleware to Http.Abstractions.

### DIFF
--- a/src/Microsoft.AspNet.Http.Abstractions/Extensions/UseMiddlewareExtensions.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/Extensions/UseMiddlewareExtensions.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Framework.DependencyInjection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Builder
 {
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Builder
                 var parameters = methodinfo.GetParameters();
                 if (parameters[0].ParameterType != typeof(HttpContext))
                 {
-                    throw new Exception("TODO: Middleware Invoke method must take first argument of HttpContext");
+                    throw new Exception("Middleware Invoke method must take first argument of HttpContext");
                 }
                 if (parameters.Length == 1)
                 {
@@ -38,7 +38,7 @@ namespace Microsoft.AspNet.Builder
                     var serviceProvider = context.RequestServices ?? context.ApplicationServices ?? applicationServices;
                     if (serviceProvider == null)
                     {
-                        throw new Exception("TODO: IServiceProvider is not available");
+                        throw new Exception("IServiceProvider is not available");
                     }
                     var arguments = new object[parameters.Length];
                     arguments[0] = context;
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Builder
                         arguments[index] = serviceProvider.GetService(serviceType);
                         if (arguments[index] == null)
                         {
-                            throw new Exception(string.Format("TODO: No service for type '{0}' has been registered.", serviceType));
+                            throw new Exception(string.Format("No service for type '{0}' has been registered.", serviceType));
                         }
                     }
                     return (Task)methodinfo.Invoke(instance, arguments);

--- a/src/Microsoft.AspNet.Http.Abstractions/project.json
+++ b/src/Microsoft.AspNet.Http.Abstractions/project.json
@@ -2,6 +2,7 @@
     "version": "1.0.0-*",
     "description": "ASP.NET 5 HTTP object model. HttpContext and family.",
     "dependencies": {
+        "Microsoft.Framework.ActivatorUtilities.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.Framework.WebEncoders.Core": "1.0.0-*"
     },
@@ -16,6 +17,7 @@
                 "System.Linq": "4.0.0-beta-*",
                 "System.Net.Primitives": "4.0.10-beta-*",
                 "System.Net.WebSockets" : "4.0.0-beta-*",
+                "System.Reflection.TypeExtensions": "4.0.0-beta-*",
                 "System.Runtime": "4.0.20-beta-*",
                 "System.Runtime.InteropServices": "4.0.20-beta-*",
                 "System.Security.Cryptography.X509Certificates": "4.0.0-beta-*",

--- a/src/Microsoft.AspNet.Http.Extensions/project.json
+++ b/src/Microsoft.AspNet.Http.Extensions/project.json
@@ -4,7 +4,6 @@
     "dependencies": {
         "Microsoft.AspNet.Http.Abstractions": "1.0.0-*",
         "Microsoft.AspNet.Http.Features": "1.0.0-*",
-        "Microsoft.Framework.DependencyInjection.Abstractions": "1.0.0-*",
         "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.Framework.WebEncoders.Core": "1.0.0-*",
         "Microsoft.Net.Http.Headers": "1.0.0-*"
@@ -15,7 +14,6 @@
         "dnxcore50": {
             "dependencies": {
                 "System.IO.FileSystem": "4.0.0-beta-*",
-                "System.Reflection.TypeExtensions": "4.0.0-beta-*",
                 "System.Runtime": "4.0.20-beta-*"
             }
         }


### PR DESCRIPTION
#311 
This reduced the required dependencies for the middleware template.

This required moving ActivatorUtilities to Common:
https://github.com/aspnet/Common/commit/8200b99dc104b19701badabb263b345d57771520

@muratg @davidfowl @rustd 