### PR TITLE
Rename OnSendingHeaders to OnResponseStarting and HeadersSent toHasStarted.

### DIFF
--- a/src/Microsoft.AspNet.Http.Abstractions/HttpResponse.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/HttpResponse.cs
@@ -22,9 +22,9 @@ namespace Microsoft.AspNet.Http
 
         public abstract IResponseCookies Cookies { get; }
 
-        public abstract bool HeadersSent { get; }
+        public abstract bool HasStarted { get; }
 
-        public abstract void OnSendingHeaders(Action<object> callback, object state);
+        public abstract void OnResponseStarting(Action<object> callback, object state);
 
         public abstract void OnResponseCompleted(Action<object> callback, object state);
 

--- a/src/Microsoft.AspNet.Http.Features/IHttpResponseFeature.cs
+++ b/src/Microsoft.AspNet.Http.Features/IHttpResponseFeature.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNet.Http.Features
         string ReasonPhrase { get; set; }
         IDictionary<string, string[]> Headers { get; set; }
         Stream Body { get; set; }
-        bool HeadersSent { get; }
-        void OnSendingHeaders(Action<object> callback, object state);
+        bool HasStarted { get; }
+        void OnResponseStarting(Action<object> callback, object state);
         void OnResponseCompleted(Action<object> callback, object state);
     }
 }

--- a/src/Microsoft.AspNet.Http/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNet.Http/DefaultHttpResponse.cs
@@ -89,14 +89,14 @@ namespace Microsoft.AspNet.Http.Internal
             get { return ResponseCookiesFeature.Cookies; }
         }
 
-        public override bool HeadersSent
+        public override bool HasStarted
         {
-            get { return HttpResponseFeature.HeadersSent; }
+            get { return HttpResponseFeature.HasStarted; }
         }
 
-        public override void OnSendingHeaders(Action<object> callback, object state)
+        public override void OnResponseStarting(Action<object> callback, object state)
         {
-            HttpResponseFeature.OnSendingHeaders(callback, state);
+            HttpResponseFeature.OnResponseStarting(callback, state);
         }
 
         public override void OnResponseCompleted(Action<object> callback, object state)

--- a/src/Microsoft.AspNet.Http/Features/HttpResponseFeature.cs
+++ b/src/Microsoft.AspNet.Http/Features/HttpResponseFeature.cs
@@ -24,12 +24,12 @@ namespace Microsoft.AspNet.Http.Features.Internal
 
         public Stream Body { get; set; }
 
-        public bool HeadersSent
+        public bool HasStarted
         {
             get { return false; }
         }
 
-        public void OnSendingHeaders(Action<object> callback, object state)
+        public void OnResponseStarting(Action<object> callback, object state)
         {
             throw new NotSupportedException();
         }

--- a/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
+++ b/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Owin
                 { OwinConstants.ResponseReasonPhrase, new FeatureMap<IHttpResponseFeature>(feature => feature.ReasonPhrase, (feature, value) => feature.ReasonPhrase = Convert.ToString(value)) },
                 { OwinConstants.ResponseHeaders, new FeatureMap<IHttpResponseFeature>(feature => feature.Headers, (feature, value) => feature.Headers = (IDictionary<string, string[]>)value) },
                 { OwinConstants.ResponseBody, new FeatureMap<IHttpResponseFeature>(feature => feature.Body, () => Stream.Null, (feature, value) => feature.Body = (Stream)value) },
-                { OwinConstants.CommonKeys.OnSendingHeaders, new FeatureMap<IHttpResponseFeature>(feature => new Action<Action<object>, object>(feature.OnSendingHeaders)) },
+                { OwinConstants.CommonKeys.OnSendingHeaders, new FeatureMap<IHttpResponseFeature>(feature => new Action<Action<object>, object>(feature.OnResponseStarting)) },
 
                 { OwinConstants.CommonKeys.LocalPort, new FeatureMap<IHttpConnectionFeature>(feature => feature.LocalPort.ToString(CultureInfo.InvariantCulture),
                     (feature, value) => feature.LocalPort = Convert.ToInt32(value, CultureInfo.InvariantCulture)) },

--- a/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
+++ b/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
@@ -142,12 +142,12 @@ namespace Microsoft.AspNet.Owin
             set { Prop(OwinConstants.ResponseBody, value); }
         }
 
-        bool IHttpResponseFeature.HeadersSent
+        bool IHttpResponseFeature.HasStarted
         {
             get { return _headersSent; }
         }
 
-        void IHttpResponseFeature.OnSendingHeaders(Action<object> callback, object state)
+        void IHttpResponseFeature.OnResponseStarting(Action<object> callback, object state)
         {
             var register = Prop<Action<Action<object>, object>>(OwinConstants.CommonKeys.OnSendingHeaders);
             if (register == null)


### PR DESCRIPTION
#320 @muratg @davidfowl 
I'll prepare the changes for dependent repos before pushing this.

Affected repos:
Kestrel
WebListener
Helios
Hosting
Stress
Security
Session
Diagnostics