### PR TITLE
Refactor IRequestIdentifierFeature.

### DIFF
--- a/src/Microsoft.AspNet.Http.Features/IHttpRequestIdentifierFeature.cs
+++ b/src/Microsoft.AspNet.Http.Features/IHttpRequestIdentifierFeature.cs
@@ -8,11 +8,11 @@ namespace Microsoft.AspNet.Http.Features
     /// <summary>
     /// Feature to identify a request.
     /// </summary>
-    public interface IRequestIdentifierFeature
+    public interface IHttpRequestIdentifierFeature
     {
         /// <summary>
         /// Identifier to trace a request.
         /// </summary>
-        Guid TraceIdentifier { get; }
+        string TraceIdentifier { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Http/Features/HttpRequestIdentifierFeature.cs
+++ b/src/Microsoft.AspNet.Http/Features/HttpRequestIdentifierFeature.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Http.Features.Internal
+{
+    public class HttpRequestIdentifierFeature : IHttpRequestIdentifierFeature
+    {
+        public string TraceIdentifier { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
+++ b/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
+using Microsoft.AspNet.Http.Features.Internal;
 using Microsoft.AspNet.Http.Features.Authentication;
 using Microsoft.AspNet.Http.Features.Authentication.Internal;
 
@@ -80,6 +81,11 @@ namespace Microsoft.AspNet.Owin
                 { OwinConstants.Security.User, new FeatureMap<IHttpAuthenticationFeature>(feature => feature.User,
                     ()=> null, (feature, value) => feature.User = Utilities.MakeClaimsPrincipal((IPrincipal)value),
                     () => new HttpAuthenticationFeature())
+                },
+
+                { OwinConstants.RequestId, new FeatureMap<IHttpRequestIdentifierFeature>(feature => feature.TraceIdentifier,
+                    ()=> null, (feature, value) => feature.TraceIdentifier = (string)value,
+                    () => new HttpRequestIdentifierFeature())
                 }
             };
 
@@ -113,9 +119,6 @@ namespace Microsoft.AspNet.Owin
             }
 
             _context.Items[typeof(HttpContext).FullName] = _context; // Store for lookup when we transition back out of OWIN
-
-            // The request identifier is a string per the spec.
-            _entries[OwinConstants.RequestId] = new FeatureMap<IRequestIdentifierFeature>(feature => feature.TraceIdentifier.ToString());
         }
 
         // Public in case there's a new/custom feature interface that needs to be added.

--- a/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
+++ b/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
@@ -30,11 +30,11 @@ namespace Microsoft.AspNet.Owin
         IHttpConnectionFeature,
         IHttpSendFileFeature,
         ITlsConnectionFeature,
+        IHttpRequestIdentifierFeature,
         IHttpRequestLifetimeFeature,
         IHttpAuthenticationFeature,
         IHttpWebSocketFeature,
-        IOwinEnvironmentFeature,
-        IRequestIdentifierFeature
+        IOwinEnvironmentFeature
     {
         public IDictionary<string, object> Environment { get; set; }
         private bool _headersSent;
@@ -435,20 +435,10 @@ namespace Microsoft.AspNet.Owin
             get { return true; }
         }
 
-        Guid IRequestIdentifierFeature.TraceIdentifier
+        string IHttpRequestIdentifierFeature.TraceIdentifier
         {
-            get
-            {
-                var requestId = Prop<string>(OwinConstants.RequestId);
-                Guid requestIdentifier;
-
-                if (requestId != null && Guid.TryParse(requestId, out requestIdentifier))
-                {
-                    return requestIdentifier;
-                }
-
-                return Guid.Empty;
-            }
+            get { return Prop<string>(OwinConstants.RequestId); }
+            set { Prop(OwinConstants.RequestId, value); }
         }
 
         public bool Remove(KeyValuePair<Type, object> item)


### PR DESCRIPTION
#310 
Rename to IHttpRequestIdenfitierFeature for consistency with other features.
Make it settable
Make the value a string instead of Guid.

This will require minor updates in Hosting, WebListener, and Helios.

@muratg @davidfowl 