### PR TITLE
Add owin.RequestUser

### DIFF
--- a/src/Microsoft.AspNet.Owin/OwinConstants.cs
+++ b/src/Microsoft.AspNet.Owin/OwinConstants.cs
@@ -20,11 +20,12 @@ namespace Microsoft.AspNet.Owin
 
         #endregion
 
-        #region OWIN v1.1.0 - 3.2.1 Request Data
+        #region OWIN v1.0.1 - 3.2.1 Request Data
 
-        // OWIN 1.1.0 http://owin.org/html/owin.html
+        // OWIN 1.0.1 http://owin.org/html/owin.html
 
         public const string RequestId = "owin.RequestId";
+        public const string RequestUser = "owin.RequestUser";
 
         #endregion
 

--- a/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
+++ b/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.WebSockets;
+using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Threading;
@@ -57,6 +58,7 @@ namespace Microsoft.AspNet.Owin
                     (feature, value) => feature.QueryString = Utilities.AddQuestionMark(Convert.ToString(value))) },
                 { OwinConstants.RequestHeaders, new FeatureMap<IHttpRequestFeature>(feature => feature.Headers, (feature, value) => feature.Headers = (IDictionary<string, string[]>)value) },
                 { OwinConstants.RequestBody, new FeatureMap<IHttpRequestFeature>(feature => feature.Body, () => Stream.Null, (feature, value) => feature.Body = (Stream)value) },
+                { OwinConstants.RequestUser, new FeatureMap<IHttpAuthenticationFeature>(feature => feature.User, () => null, (feature, value) => feature.User = (ClaimsPrincipal)value) },
 
                 { OwinConstants.ResponseStatusCode, new FeatureMap<IHttpResponseFeature>(feature => feature.StatusCode, () => 200, (feature, value) => feature.StatusCode = Convert.ToInt32(value)) },
                 { OwinConstants.ResponseReasonPhrase, new FeatureMap<IHttpResponseFeature>(feature => feature.ReasonPhrase, (feature, value) => feature.ReasonPhrase = Convert.ToString(value)) },

--- a/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
+++ b/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
@@ -263,8 +263,16 @@ namespace Microsoft.AspNet.Owin
 
         ClaimsPrincipal IHttpAuthenticationFeature.User
         {
-            get { return Utilities.MakeClaimsPrincipal(Prop<IPrincipal>(OwinConstants.Security.User)); }
-            set { Prop(OwinConstants.Security.User, value); }
+            get
+            {
+                return Prop<ClaimsPrincipal>(OwinConstants.RequestUser)
+                    ?? Utilities.MakeClaimsPrincipal(Prop<IPrincipal>(OwinConstants.Security.User));
+            }
+            set
+            {
+                Prop(OwinConstants.RequestUser, value);
+                Prop(OwinConstants.Security.User, value);
+            }
         }
 
         IAuthenticationHandler IHttpAuthenticationFeature.Handler { get; set; }


### PR DESCRIPTION
The key `owin.RequestUser` was voted on and accepted as part of https://github.com/owin/owin/issues/9, and has been added to the spec under [Section 3.2.1 Request Data](https://github.com/owin/owin/blob/21851966ab304187ad6700850daf0294a4ec7a4e/owin.md#321-request-data).

This PR adds the key to the environment and feature collection :sparkles: 

The property will set both `server.User` and `owin.RequestUser`, as well as fall back from `owin.RequestUser` to `server.User` on retrieval, for interoperability reasons.