### PR TITLE
Introduce StringValues to replace string[] usage.

### DIFF
--- a/HttpAbstractions.sln
+++ b/HttpAbstractions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A5A15F1C-885A-452A-A731-B0173DDBD913}"
 EndProject
@@ -42,6 +42,14 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.WebEncoders.Core", "src\Microsoft.Framework.WebEncoders.Core\Microsoft.Framework.WebEncoders.Core.xproj", "{BE9112CB-D87D-4080-9CC3-24492D49CBE6}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Html.Abstractions", "src\Microsoft.AspNet.Html.Abstractions\Microsoft.AspNet.Html.Abstractions.xproj", "{68A28E4A-3ADE-4187-9625-4FF185887CB3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{982F09D8-621E-4872-BA7B-BBDEA47D1EFD}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "SampleApp", "samples\SampleApp\SampleApp.xproj", "{1D0764B4-1DEB-4232-A714-D4B7E846918A}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Primitives", "src\Microsoft.Framework.Primitives\Microsoft.Framework.Primitives.xproj", "{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Primitives.Tests", "test\Microsoft.Framework.Primitives.Tests\Microsoft.Framework.Primitives.Tests.xproj", "{61F72E92-B3AE-4A10-B838-44F80AED40AE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -245,6 +253,42 @@ Global
 		{68A28E4A-3ADE-4187-9625-4FF185887CB3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{68A28E4A-3ADE-4187-9625-4FF185887CB3}.Release|x86.ActiveCfg = Release|Any CPU
 		{68A28E4A-3ADE-4187-9625-4FF185887CB3}.Release|x86.Build.0 = Release|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Debug|x86.Build.0 = Debug|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Release|x86.ActiveCfg = Release|Any CPU
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A}.Release|x86.Build.0 = Release|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Debug|x86.Build.0 = Debug|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Release|x86.ActiveCfg = Release|Any CPU
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A}.Release|x86.Build.0 = Release|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Debug|x86.Build.0 = Debug|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Release|x86.ActiveCfg = Release|Any CPU
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -268,5 +312,8 @@ Global
 		{7AE2731D-43CD-4CF8-850A-4914DE2CE930} = {F31FF137-390C-49BF-A3BD-7C6ED3597C21}
 		{BE9112CB-D87D-4080-9CC3-24492D49CBE6} = {A5A15F1C-885A-452A-A731-B0173DDBD913}
 		{68A28E4A-3ADE-4187-9625-4FF185887CB3} = {A5A15F1C-885A-452A-A731-B0173DDBD913}
+		{1D0764B4-1DEB-4232-A714-D4B7E846918A} = {982F09D8-621E-4872-BA7B-BBDEA47D1EFD}
+		{E5FACCD4-6327-43AA-80A9-AE6F4A3BFE6A} = {A5A15F1C-885A-452A-A731-B0173DDBD913}
+		{61F72E92-B3AE-4A10-B838-44F80AED40AE} = {F31FF137-390C-49BF-A3BD-7C6ED3597C21}
 	EndGlobalSection
 EndGlobal

--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Framework.Primitives;
+
+namespace SampleApp
+{
+    public class Program
+    {
+        public void Main(string[] args)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                Stopwatch timer = new Stopwatch();
+                timer.Start();
+                string myString;
+                string[] myArray;
+                StringValues myValues;
+                for (int j = 0; j < 100000000; j++)
+                {
+                    myString = new string('a', 40);
+                    myArray = new[] { myString };
+                    // myValues = new StringValues(myString);
+                    myValues = new StringValues(myArray);
+                }
+                timer.Stop();
+                Console.WriteLine(timer.Elapsed + ", " + Environment.WorkingSet);
+            }
+        }
+    }
+}

--- a/samples/SampleApp/SampleApp.xproj
+++ b/samples/SampleApp/SampleApp.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>1d0764b4-1deb-4232-a714-d4b7e846918a</ProjectGuid>
+    <RootNamespace>SampleApp</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -1,0 +1,15 @@
+﻿{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "Microsoft.AspNet.Http": "1.0.0-*"
+  },
+
+  "commands": {
+    "SampleApp": "SampleApp"
+  },
+
+  "frameworks": {
+    "dnx451": { }
+  }
+}

--- a/src/Microsoft.AspNet.Http.Abstractions/IHeaderDictionary.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/IHeaderDictionary.cs
@@ -2,29 +2,30 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http
 {
     /// <summary>
     /// Represents request and response headers
     /// </summary>
-    public interface IHeaderDictionary : IReadableStringCollection, IDictionary<string, string[]>
+    public interface IHeaderDictionary : IReadableStringCollection, IDictionary<string, StringValues>
     {
+        // This property is duplicated to resolve an ambiguity between IReadableStringCollection and IDictionary<string, StringValues>
         /// <summary>
-        /// Get or sets the associated value from the collection as a single string.
+        ///
         /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <returns>the associated value from the collection as a single string or null if the key is not present.</returns>
-        new string this[string key] { get; set; }
+        /// <param name="key"></param>
+        /// <returns>The stored value, or StringValues.Empty if the key is not present.</returns>
+        new StringValues this[string key] { get; set; }
 
-        // This property is duplicated to resolve an ambiguity between IReadableStringCollection.Count and IDictionary<string, string[]>.Count
+        // This property is duplicated to resolve an ambiguity between IReadableStringCollection.Count and IDictionary<string, StringValues>.Count
         /// <summary>
         /// Gets the number of elements contained in the collection.
         /// </summary>
         new int Count { get; }
 
-        // This property is duplicated to resolve an ambiguity between IReadableStringCollection.Keys and IDictionary<string, string[]>.Keys
+        // This property is duplicated to resolve an ambiguity between IReadableStringCollection.Keys and IDictionary<string, StringValues>.Keys
         /// <summary>
         /// Gets a collection containing the keys.
         /// </summary>
@@ -36,21 +37,14 @@ namespace Microsoft.AspNet.Http
         /// </summary>
         /// <param name="key">The header name.</param>
         /// <returns>the associated values from the collection separated into individual values, or null if the key is not present.</returns>
-        IList<string> GetCommaSeparatedValues(string key);
+        StringValues GetCommaSeparatedValues(string key);
 
         /// <summary>
-        /// Add a new value. Appends to the header if already present
+        /// Add a new value. Appends to the header list if already present
         /// </summary>
         /// <param name="key">The header name.</param>
         /// <param name="value">The header value.</param>
-        void Append(string key, string value);
-
-        /// <summary>
-        /// Add new values. Each item remains a separate array entry.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="values">The header values.</param>
-        void AppendValues(string key, params string[] values);
+        void Append(string key, StringValues value);
 
         /// <summary>
         /// Quotes any values containing comas, and then coma joins all of the values with any existing values.
@@ -58,21 +52,6 @@ namespace Microsoft.AspNet.Http
         /// <param name="key">The header name.</param>
         /// <param name="values">The header values.</param>
         void AppendCommaSeparatedValues(string key, params string[] values);
-
-        /// <summary>
-        /// Sets a specific header value.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="value">The header value.</param>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Set", Justification = "Re-evaluate later.")]
-        void Set(string key, string value);
-
-        /// <summary>
-        /// Sets the specified header values without modification.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="values">The header values.</param>
-        void SetValues(string key, params string[] values);
 
         /// <summary>
         /// Quotes any values containing comas, and then coma joins all of the values.

--- a/src/Microsoft.AspNet.Http.Abstractions/IHeaderDictionary.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/IHeaderDictionary.cs
@@ -30,34 +30,5 @@ namespace Microsoft.AspNet.Http
         /// Gets a collection containing the keys.
         /// </summary>
         new ICollection<string> Keys { get; }
-
-        /// <summary>
-        /// Get the associated values from the collection separated into individual values.
-        /// Quoted values will not be split, and the quotes will be removed.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <returns>the associated values from the collection separated into individual values, or null if the key is not present.</returns>
-        StringValues GetCommaSeparatedValues(string key);
-
-        /// <summary>
-        /// Add a new value. Appends to the header list if already present
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="value">The header value.</param>
-        void Append(string key, StringValues value);
-
-        /// <summary>
-        /// Quotes any values containing comas, and then coma joins all of the values with any existing values.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="values">The header values.</param>
-        void AppendCommaSeparatedValues(string key, params string[] values);
-
-        /// <summary>
-        /// Quotes any values containing comas, and then coma joins all of the values.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="values">The header values.</param>
-        void SetCommaSeparatedValues(string key, params string[] values);
     }
 }

--- a/src/Microsoft.AspNet.Http.Abstractions/IReadableStringCollection.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/IReadableStringCollection.cs
@@ -2,22 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http
 {
     /// <summary>
     /// Accessors for headers, query, forms, etc.
     /// </summary>
-    public interface IReadableStringCollection : IEnumerable<KeyValuePair<string, string[]>>
+    public interface IReadableStringCollection : IEnumerable<KeyValuePair<string, StringValues>>
     {
         /// <summary>
-        /// Get the associated value from the collection.  Multiple values will be merged.
-        /// Returns null if the key is not present.
+        /// Get the associated value from the collection.
+        /// Returns StringValues.Empty if the key is not present.
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        string this[string key] { get; }
+        StringValues this[string key] { get; }
 
         /// <summary>
         /// Gets the number of elements contained in the collection.
@@ -35,22 +35,5 @@ namespace Microsoft.AspNet.Http
         /// <param name="key"></param>
         /// <returns></returns>
         bool ContainsKey(string key);
-
-        /// <summary>
-        /// Get the associated value from the collection.  Multiple values will be merged.
-        /// Returns null if the key is not present.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Re-evaluate later.")]
-        string Get(string key);
-
-        /// <summary>
-        /// Get the associated values from the collection in their original format.
-        /// Returns null if the key is not present.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        IList<string> GetValues(string key);
     }
 }

--- a/src/Microsoft.AspNet.Http.Abstractions/QueryString.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/QueryString.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 using Microsoft.Framework.WebEncoders;
 
 namespace Microsoft.AspNet.Http
@@ -143,7 +144,7 @@ namespace Microsoft.AspNet.Http
         /// </summary>
         /// <param name="parameters"></param>
         /// <returns>The resulting QueryString</returns>
-        public static QueryString Create(IEnumerable<KeyValuePair<string, string[]>> parameters)
+        public static QueryString Create(IEnumerable<KeyValuePair<string, StringValues>> parameters)
         {
             var builder = new StringBuilder();
             bool first = true;

--- a/src/Microsoft.AspNet.Http.Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/HeaderDictionaryExtensions.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Http.Internal;
+using Microsoft.Framework.Primitives;
+
+namespace Microsoft.AspNet.Http
+{
+    public static class HeaderDictionaryExtensions
+    {
+        /// <summary>
+        /// Add new values. Each item remains a separate array entry.
+        /// </summary>
+        /// <param name="key">The header name.</param>
+        /// <param name="value">The header value.</param>
+        public static void Append(this IHeaderDictionary headers, string key, StringValues value)
+        {
+            ParsingHelpers.AppendHeaderUnmodified(headers, key, value);
+        }
+
+        /// <summary>
+        /// Quotes any values containing comas, and then coma joins all of the values with any existing values.
+        /// </summary>
+        /// <param name="key">The header name.</param>
+        /// <param name="values">The header values.</param>
+        public static void AppendCommaSeparatedValues(this IHeaderDictionary headers, string key, params string[] values)
+        {
+            ParsingHelpers.AppendHeaderJoined(headers, key, values);
+        }
+
+        /// <summary>
+        /// Get the associated values from the collection separated into individual values.
+        /// Quoted values will not be split, and the quotes will be removed.
+        /// </summary>
+        /// <param name="key">The header name.</param>
+        /// <returns>the associated values from the collection separated into individual values, or StringValues.Empty if the key is not present.</returns>
+        public static string[] GetCommaSeparatedValues(this IHeaderDictionary headers, string key)
+        {
+            return ParsingHelpers.GetHeaderSplit(headers, key);
+        }
+
+        /// <summary>
+        /// Quotes any values containing comas, and then coma joins all of the values.
+        /// </summary>
+        /// <param name="key">The header name.</param>
+        /// <param name="values">The header values.</param>
+        public static void SetCommaSeparatedValues(this IHeaderDictionary headers, string key, params string[] values)
+        {
+            ParsingHelpers.SetHeaderJoined(headers, key, values);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Http.Extensions/HeaderDictionaryTypeExtensions.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/HeaderDictionaryTypeExtensions.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Http.Headers;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http
@@ -50,7 +51,7 @@ namespace Microsoft.AspNet.Http
             }
             else
             {
-                headers.SetValues(name, values.Select(value => value.ToString()).ToArray());
+                headers[name] = values.Select(value => value.ToString()).ToArray();
             }
         }
 
@@ -98,7 +99,7 @@ namespace Microsoft.AspNet.Http
             }
 
             var value = headers[name];
-            if (string.IsNullOrWhiteSpace(value))
+            if (StringValues.IsNullOrEmpty(value))
             {
                 return default(T);
             }
@@ -112,11 +113,11 @@ namespace Microsoft.AspNet.Http
             if (KnownListParsers.TryGetValue(typeof(T), out temp))
             {
                 var func = (Func<IList<string>, IList<T>>)temp;
-                return func(headers.GetValues(name));
+                return func(headers[name]);
             }
 
-            var values = headers.GetValues(name);
-            if (values == null || !values.Any())
+            var values = headers[name];
+            if (StringValues.IsNullOrEmpty(values))
             {
                 return null;
             }
@@ -158,7 +159,7 @@ namespace Microsoft.AspNet.Http
             return default(T);
         }
 
-        private static IList<T> GetListViaReflection<T>(IList<string> values)
+        private static IList<T> GetListViaReflection<T>(StringValues values)
         {
             // TODO: Cache the reflected type for later? Only if success?
             var type = typeof(T);

--- a/src/Microsoft.AspNet.Http.Extensions/RequestHeaders.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/RequestHeaders.cs
@@ -285,7 +285,7 @@ namespace Microsoft.AspNet.Http.Headers
 
         public void AppendList<T>([NotNull] string name, [NotNull] IList<T> values)
         {
-            Headers.AppendValues(name, values.Select(value => value.ToString()).ToArray());
+            Headers.Append(name, values.Select(value => value.ToString()).ToArray());
         }
     }
 }

--- a/src/Microsoft.AspNet.Http.Extensions/ResponseHeaders.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/ResponseHeaders.cs
@@ -182,7 +182,7 @@ namespace Microsoft.AspNet.Http.Headers
 
         public void AppendList<T>([NotNull] string name, [NotNull] IList<T> values)
         {
-            Headers.AppendValues(name, values.Select(value => value.ToString()).ToArray());
+            Headers.Append(name, values.Select(value => value.ToString()).ToArray());
         }
     }
 }

--- a/src/Microsoft.AspNet.Http.Features/IHttpRequestFeature.cs
+++ b/src/Microsoft.AspNet.Http.Features/IHttpRequestFeature.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http.Features
 {
@@ -14,7 +15,7 @@ namespace Microsoft.AspNet.Http.Features
         string PathBase { get; set; }
         string Path { get; set; }
         string QueryString { get; set; }
-        IDictionary<string, string[]> Headers { get; set; }
+        IDictionary<string, StringValues> Headers { get; set; }
         Stream Body { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Http.Features/IHttpResponseFeature.cs
+++ b/src/Microsoft.AspNet.Http.Features/IHttpResponseFeature.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http.Features
 {
@@ -12,7 +13,7 @@ namespace Microsoft.AspNet.Http.Features
     {
         int StatusCode { get; set; }
         string ReasonPhrase { get; set; }
-        IDictionary<string, string[]> Headers { get; set; }
+        IDictionary<string, StringValues> Headers { get; set; }
         Stream Body { get; set; }
         bool HasStarted { get; }
         void OnStarting(Func<object, Task> callback, object state);

--- a/src/Microsoft.AspNet.Http.Features/project.json
+++ b/src/Microsoft.AspNet.Http.Features/project.json
@@ -6,7 +6,11 @@
         "url": "git://github.com/aspnet/httpabstractions"
     },
     "dependencies": {
-        "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" }
+        "Microsoft.Framework.NotNullAttribute.Sources": {
+            "type": "build",
+            "version": "1.0.0-*"
+        },
+        "Microsoft.Framework.Primitives": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },

--- a/src/Microsoft.AspNet.Http/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNet.Http/DefaultHttpResponse.cs
@@ -68,8 +68,7 @@ namespace Microsoft.AspNet.Http.Internal
         {
             get
             {
-                var contentType = Headers[HeaderNames.ContentType];
-                return contentType;
+                return Headers[HeaderNames.ContentType];
             }
             set
             {
@@ -79,7 +78,7 @@ namespace Microsoft.AspNet.Http.Internal
                 }
                 else
                 {
-                    HttpResponseFeature.Headers[HeaderNames.ContentType] = new[] { value };
+                    HttpResponseFeature.Headers[HeaderNames.ContentType] = value;
                 }
             }
         }
@@ -115,7 +114,7 @@ namespace Microsoft.AspNet.Http.Internal
                 HttpResponseFeature.StatusCode = 302;
             }
 
-            Headers.Set(HeaderNames.Location, location);
+            Headers[HeaderNames.Location] = location;
         }
     }
 }

--- a/src/Microsoft.AspNet.Http/DefaultWebSocketManager.cs
+++ b/src/Microsoft.AspNet.Http/DefaultWebSocketManager.cs
@@ -12,8 +12,6 @@ namespace Microsoft.AspNet.Http.Internal
 {
     public class DefaultWebSocketManager : WebSocketManager
     {
-        private static IList<string> EmptyList = new List<string>();
-
         private IFeatureCollection _features;
         private FeatureReference<IHttpRequestFeature> _request = FeatureReference<IHttpRequestFeature>.Default;
         private FeatureReference<IHttpWebSocketFeature> _webSockets = FeatureReference<IHttpWebSocketFeature>.Default;
@@ -45,8 +43,7 @@ namespace Microsoft.AspNet.Http.Internal
         {
             get
             {
-                return ParsingHelpers.GetHeaderUnmodified(HttpRequestFeature.Headers,
-                    HeaderNames.WebSocketSubProtocols) ?? EmptyList;
+                return ParsingHelpers.GetHeaderSplit(HttpRequestFeature.Headers, HeaderNames.WebSocketSubProtocols);
             }
         }
 

--- a/src/Microsoft.AspNet.Http/Features/HttpRequestFeature.cs
+++ b/src/Microsoft.AspNet.Http/Features/HttpRequestFeature.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http.Features.Internal
 {
@@ -11,7 +12,7 @@ namespace Microsoft.AspNet.Http.Features.Internal
     {
         public HttpRequestFeature()
         {
-            Headers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            Headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
             Body = Stream.Null;
             Protocol = string.Empty;
             Scheme = string.Empty;
@@ -27,7 +28,7 @@ namespace Microsoft.AspNet.Http.Features.Internal
         public string PathBase { get; set; }
         public string Path { get; set; }
         public string QueryString { get; set; }
-        public IDictionary<string, string[]> Headers { get; set; }
+        public IDictionary<string, StringValues> Headers { get; set; }
         public Stream Body { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Http/Features/HttpResponseFeature.cs
+++ b/src/Microsoft.AspNet.Http/Features/HttpResponseFeature.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http.Features.Internal
 {
@@ -13,7 +14,7 @@ namespace Microsoft.AspNet.Http.Features.Internal
         public HttpResponseFeature()
         {
             StatusCode = 200;
-            Headers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            Headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
             Body = Stream.Null;
         }
 
@@ -21,7 +22,7 @@ namespace Microsoft.AspNet.Http.Features.Internal
 
         public string ReasonPhrase { get; set; }
 
-        public IDictionary<string, string[]> Headers { get; set; }
+        public IDictionary<string, StringValues> Headers { get; set; }
 
         public Stream Body { get; set; }
 

--- a/src/Microsoft.AspNet.Http/FormCollection.cs
+++ b/src/Microsoft.AspNet.Http/FormCollection.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http.Internal
 {
@@ -11,12 +12,12 @@ namespace Microsoft.AspNet.Http.Internal
     /// </summary>
     public class FormCollection : ReadableStringCollection, IFormCollection
     {
-        public FormCollection([NotNull] IDictionary<string, string[]> store)
+        public FormCollection([NotNull] IDictionary<string, StringValues> store)
             : this(store, new FormFileCollection())
         {
         }
 
-        public FormCollection([NotNull] IDictionary<string, string[]> store, [NotNull] IFormFileCollection files)
+        public FormCollection([NotNull] IDictionary<string, StringValues> store, [NotNull] IFormFileCollection files)
             : base(store)
         {
             Files = files;

--- a/src/Microsoft.AspNet.Http/HeaderDictionary.cs
+++ b/src/Microsoft.AspNet.Http/HeaderDictionary.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.AspNet.Http.Internal;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http.Internal
 {
@@ -15,7 +14,7 @@ namespace Microsoft.AspNet.Http.Internal
     /// </summary>
     public class HeaderDictionary : IHeaderDictionary
     {
-        public HeaderDictionary() : this(new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase))
+        public HeaderDictionary() : this(new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase))
         {
         }
 
@@ -23,12 +22,12 @@ namespace Microsoft.AspNet.Http.Internal
         /// Initializes a new instance of the <see cref="T:Microsoft.Owin.HeaderDictionary" /> class.
         /// </summary>
         /// <param name="store">The underlying data store.</param>
-        public HeaderDictionary([NotNull] IDictionary<string, string[]> store)
+        public HeaderDictionary([NotNull] IDictionary<string, StringValues> store)
         {
             Store = store;
         }
 
-        private IDictionary<string, string[]> Store { get; set; }
+        private IDictionary<string, StringValues> Store { get; set; }
 
         /// <summary>
         /// Gets an <see cref="T:System.Collections.ICollection" /> that contains the keys in the <see cref="T:Microsoft.Owin.HeaderDictionary" />;.
@@ -42,7 +41,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// <summary>
         /// 
         /// </summary>
-        public ICollection<string[]> Values
+        public ICollection<StringValues> Values
         {
             get { return Store.Values; }
         }
@@ -69,11 +68,11 @@ namespace Microsoft.AspNet.Http.Internal
         /// Get or sets the associated value from the collection as a single string.
         /// </summary>
         /// <param name="key">The header name.</param>
-        /// <returns>the associated value from the collection as a single string or null if the key is not present.</returns>
-        public string this[string key]
+        /// <returns>the associated value from the collection as a StringValues or StringValues.Empty if the key is not present.</returns>
+        public StringValues this[string key]
         {
-            get { return Get(key); }
-            set { Set(key, value); }
+            get { return ParsingHelpers.GetHeader(Store, key); }
+            set { ParsingHelpers.SetHeader(Store, key, value); }
         }
 
         /// <summary>
@@ -81,7 +80,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// </summary>
         /// <param name="key">The header name.</param>
         /// <returns></returns>
-        string[] IDictionary<string, string[]>.this[string key]
+        StringValues IDictionary<string, StringValues>.this[string key]
         {
             get { return Store[key]; }
             set { Store[key] = value; }
@@ -91,7 +90,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
-        public IEnumerator<KeyValuePair<string, string[]>> GetEnumerator()
+        IEnumerator<KeyValuePair<string, StringValues>> IEnumerable<KeyValuePair<string, StringValues>>.GetEnumerator()
         {
             return Store.GetEnumerator();
         }
@@ -102,59 +101,29 @@ namespace Microsoft.AspNet.Http.Internal
         /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
+            return Store.GetEnumerator();
         }
 
-        /// <summary>
-        /// Get the associated value from the collection as a single string.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <returns>the associated value from the collection as a single string or null if the key is not present.</returns>
-        public string Get(string key)
-        {
-            return ParsingHelpers.GetHeader(Store, key);
-        }
-
-        /// <summary>
-        /// Get the associated values from the collection without modification.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <returns>the associated value from the collection without modification, or null if the key is not present.</returns>
-        public IList<string> GetValues(string key)
-        {
-            return ParsingHelpers.GetHeaderUnmodified(Store, key);
-        }
 
         /// <summary>
         /// Get the associated values from the collection separated into individual values.
         /// Quoted values will not be split, and the quotes will be removed.
         /// </summary>
         /// <param name="key">The header name.</param>
-        /// <returns>the associated values from the collection separated into individual values, or null if the key is not present.</returns>
-        public IList<string> GetCommaSeparatedValues(string key)
+        /// <returns>the associated values from the collection separated into individual values, or StringValues.Empty if the key is not present.</returns>
+        public StringValues GetCommaSeparatedValues(string key)
         {
-            IEnumerable<string> values = ParsingHelpers.GetHeaderSplit(Store, key);
-            return values == null ? null : values.ToList();
-        }
-
-        /// <summary>
-        /// Add a new value. Appends to the header if already present
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="value">The header value.</param>
-        public void Append(string key, string value)
-        {
-            ParsingHelpers.AppendHeader(Store, key, value);
+            return ParsingHelpers.GetHeaderSplit(Store, key);
         }
 
         /// <summary>
         /// Add new values. Each item remains a separate array entry.
         /// </summary>
         /// <param name="key">The header name.</param>
-        /// <param name="values">The header values.</param>
-        public void AppendValues(string key, params string[] values)
+        /// <param name="value">The header value.</param>
+        public void Append(string key, StringValues value)
         {
-            ParsingHelpers.AppendHeaderUnmodified(Store, key, values);
+            ParsingHelpers.AppendHeaderUnmodified(Store, key, value);
         }
 
         /// <summary>
@@ -165,26 +134,6 @@ namespace Microsoft.AspNet.Http.Internal
         public void AppendCommaSeparatedValues(string key, params string[] values)
         {
             ParsingHelpers.AppendHeaderJoined(Store, key, values);
-        }
-
-        /// <summary>
-        /// Sets a specific header value.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="value">The header value.</param>
-        public void Set(string key, string value)
-        {
-            ParsingHelpers.SetHeader(Store, key, value);
-        }
-
-        /// <summary>
-        /// Sets the specified header values without modification.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="values">The header values.</param>
-        public void SetValues(string key, params string[] values)
-        {
-            ParsingHelpers.SetHeaderUnmodified(Store, key, values);
         }
 
         /// <summary>
@@ -202,7 +151,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// </summary>
         /// <param name="key">The header name.</param>
         /// <param name="value">The header values.</param>
-        public void Add(string key, string[] value)
+        public void Add(string key, StringValues value)
         {
             Store.Add(key, value);
         }
@@ -233,7 +182,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// <param name="key">The header name.</param>
         /// <param name="value">The value.</param>
         /// <returns>true if the <see cref="T:Microsoft.Owin.HeaderDictionary" /> contains the key; otherwise, false.</returns>
-        public bool TryGetValue(string key, out string[] value)
+        public bool TryGetValue(string key, out StringValues value)
         {
             return Store.TryGetValue(key, out value);
         }
@@ -242,7 +191,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// Adds a new list of items to the collection.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        public void Add(KeyValuePair<string, string[]> item)
+        public void Add(KeyValuePair<string, StringValues> item)
         {
             Store.Add(item);
         }
@@ -260,7 +209,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// </summary>
         /// <param name="item">The item.</param>
         /// <returns>true if the specified object occurs within this collection; otherwise, false.</returns>
-        public bool Contains(KeyValuePair<string, string[]> item)
+        public bool Contains(KeyValuePair<string, StringValues> item)
         {
             return Store.Contains(item);
         }
@@ -270,7 +219,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// </summary>
         /// <param name="array">The one-dimensional Array that is the destination of the specified objects copied from the <see cref="T:Microsoft.Owin.HeaderDictionary" />.</param>
         /// <param name="arrayIndex">The zero-based index in <paramref name="array" /> at which copying begins.</param>
-        public void CopyTo(KeyValuePair<string, string[]>[] array, int arrayIndex)
+        public void CopyTo(KeyValuePair<string, StringValues>[] array, int arrayIndex)
         {
             Store.CopyTo(array, arrayIndex);
         }
@@ -280,7 +229,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// </summary>
         /// <param name="item">The item.</param>
         /// <returns>true if the specified object was removed from the collection; otherwise, false.</returns>
-        public bool Remove(KeyValuePair<string, string[]> item)
+        public bool Remove(KeyValuePair<string, StringValues> item)
         {
             return Store.Remove(item);
         }

--- a/src/Microsoft.AspNet.Http/HeaderDictionary.cs
+++ b/src/Microsoft.AspNet.Http/HeaderDictionary.cs
@@ -104,48 +104,6 @@ namespace Microsoft.AspNet.Http.Internal
             return Store.GetEnumerator();
         }
 
-
-        /// <summary>
-        /// Get the associated values from the collection separated into individual values.
-        /// Quoted values will not be split, and the quotes will be removed.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <returns>the associated values from the collection separated into individual values, or StringValues.Empty if the key is not present.</returns>
-        public StringValues GetCommaSeparatedValues(string key)
-        {
-            return ParsingHelpers.GetHeaderSplit(Store, key);
-        }
-
-        /// <summary>
-        /// Add new values. Each item remains a separate array entry.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="value">The header value.</param>
-        public void Append(string key, StringValues value)
-        {
-            ParsingHelpers.AppendHeaderUnmodified(Store, key, value);
-        }
-
-        /// <summary>
-        /// Quotes any values containing comas, and then coma joins all of the values with any existing values.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="values">The header values.</param>
-        public void AppendCommaSeparatedValues(string key, params string[] values)
-        {
-            ParsingHelpers.AppendHeaderJoined(Store, key, values);
-        }
-
-        /// <summary>
-        /// Quotes any values containing comas, and then coma joins all of the values.
-        /// </summary>
-        /// <param name="key">The header name.</param>
-        /// <param name="values">The header values.</param>
-        public void SetCommaSeparatedValues(string key, params string[] values)
-        {
-            ParsingHelpers.SetHeaderJoined(Store, key, values);
-        }
-
         /// <summary>
         /// Adds the given header and values to the collection.
         /// </summary>

--- a/src/Microsoft.AspNet.Http/ReadableStringCollection.cs
+++ b/src/Microsoft.AspNet.Http/ReadableStringCollection.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http.Internal
 {
@@ -12,16 +13,18 @@ namespace Microsoft.AspNet.Http.Internal
     /// </summary>
     public class ReadableStringCollection : IReadableStringCollection
     {
+        public static readonly IReadableStringCollection Empty = new ReadableStringCollection(new Dictionary<string, StringValues>(0));
+
         /// <summary>
         /// Create a new wrapper
         /// </summary>
         /// <param name="store"></param>
-        public ReadableStringCollection([NotNull] IDictionary<string, string[]> store)
+        public ReadableStringCollection([NotNull] IDictionary<string, StringValues> store)
         {
             Store = store;
         }
 
-        private IDictionary<string, string[]> Store { get; set; }
+        private IDictionary<string, StringValues> Store { get; set; }
 
         /// <summary>
         /// Gets the number of elements contained in the collection.
@@ -42,13 +45,21 @@ namespace Microsoft.AspNet.Http.Internal
 
         /// <summary>
         /// Get the associated value from the collection.  Multiple values will be merged.
-        /// Returns null if the key is not present.
+        /// Returns StringValues.Empty if the key is not present.
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        public string this[string key]
+        public StringValues this[string key]
         {
-            get { return Get(key); }
+            get
+            {
+                StringValues value;
+                if (Store.TryGetValue(key, out value))
+                {
+                    return value;
+                }
+                return StringValues.Empty;
+            }
         }
 
         /// <summary>
@@ -61,35 +72,12 @@ namespace Microsoft.AspNet.Http.Internal
             return Store.ContainsKey(key);
         }
 
-        /// <summary>
-        /// Get the associated value from the collection.  Multiple values will be merged.
-        /// Returns null if the key is not present.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public string Get(string key)
-        {
-            return GetJoinedValue(Store, key);
-        }
-
-        /// <summary>
-        /// Get the associated values from the collection in their original format.
-        /// Returns null if the key is not present.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public IList<string> GetValues(string key)
-        {
-            string[] values;
-            Store.TryGetValue(key, out values);
-            return values;
-        }
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>
-        public IEnumerator<KeyValuePair<string, string[]>> GetEnumerator()
+        public IEnumerator<KeyValuePair<string, StringValues>> GetEnumerator()
         {
             return Store.GetEnumerator();
         }
@@ -101,16 +89,6 @@ namespace Microsoft.AspNet.Http.Internal
         IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
-        }
-
-        private static string GetJoinedValue(IDictionary<string, string[]> store, string key)
-        {
-            string[] values;
-            if (store.TryGetValue(key, out values))
-            {
-                return string.Join(",", values);
-            }
-            return null;
         }
     }
 }

--- a/src/Microsoft.AspNet.Http/RequestCookiesCollection.cs
+++ b/src/Microsoft.AspNet.Http/RequestCookiesCollection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Framework.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Internal
@@ -17,7 +18,7 @@ namespace Microsoft.AspNet.Http.Internal
             _dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
-        public string this[string key]
+        public StringValues this[string key]
         {
             get { return Get(key); }
         }
@@ -88,11 +89,11 @@ namespace Microsoft.AspNet.Http.Internal
             }
         }
 
-        public IEnumerator<KeyValuePair<string, string[]>> GetEnumerator()
+        public IEnumerator<KeyValuePair<string, StringValues>> GetEnumerator()
         {
             foreach (var pair in _dictionary)
             {
-                yield return new KeyValuePair<string, string[]>(pair.Key, new[] { pair.Value });
+                yield return new KeyValuePair<string, StringValues>(pair.Key, pair.Value);
             }
         }
 

--- a/src/Microsoft.AspNet.Owin/DictionaryStringArrayWrapper.cs
+++ b/src/Microsoft.AspNet.Owin/DictionaryStringArrayWrapper.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.Primitives;
+
+namespace Microsoft.AspNet.Owin
+{
+    internal class DictionaryStringArrayWrapper : IDictionary<string, string[]>
+    {
+        public DictionaryStringArrayWrapper(IDictionary<string, StringValues> inner)
+        {
+            Inner = inner;
+        }
+
+        public readonly IDictionary<string, StringValues> Inner;
+
+        private KeyValuePair<string, StringValues> Convert(KeyValuePair<string, string[]> item) => new KeyValuePair<string, StringValues>(item.Key, item.Value);
+
+        private KeyValuePair<string, string[]> Convert(KeyValuePair<string, StringValues> item) => new KeyValuePair<string, string[]>(item.Key, item.Value);
+
+        private StringValues Convert(string[] item) => item;
+
+        private string[] Convert(StringValues item) => item;
+
+        string[] IDictionary<string, string[]>.this[string key]
+        {
+            get { return Inner[key]; }
+            set { Inner[key] = value; }
+        }
+
+        int ICollection<KeyValuePair<string, string[]>>.Count => Inner.Count;
+
+        bool ICollection<KeyValuePair<string, string[]>>.IsReadOnly => Inner.IsReadOnly;
+
+        ICollection<string> IDictionary<string, string[]>.Keys => Inner.Keys;
+
+        ICollection<string[]> IDictionary<string, string[]>.Values => Inner.Values.Select(Convert).ToList();
+
+        void ICollection<KeyValuePair<string, string[]>>.Add(KeyValuePair<string, string[]> item) => Inner.Add(Convert(item));
+
+        void IDictionary<string, string[]>.Add(string key, string[] value) => Inner.Add(key, value);
+
+        void ICollection<KeyValuePair<string, string[]>>.Clear() => Inner.Clear();
+
+        bool ICollection<KeyValuePair<string, string[]>>.Contains(KeyValuePair<string, string[]> item) => Inner.Contains(Convert(item));
+
+        bool IDictionary<string, string[]>.ContainsKey(string key) => Inner.ContainsKey(key);
+
+        void ICollection<KeyValuePair<string, string[]>>.CopyTo(KeyValuePair<string, string[]>[] array, int arrayIndex)
+        {
+            foreach(var kv in Inner)
+            {
+                array[arrayIndex++] = Convert(kv);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => Inner.Select(Convert).GetEnumerator();
+
+        IEnumerator<KeyValuePair<string, string[]>> IEnumerable<KeyValuePair<string, string[]>>.GetEnumerator() => Inner.Select(Convert).GetEnumerator();
+
+        bool ICollection<KeyValuePair<string, string[]>>.Remove(KeyValuePair<string, string[]> item) => Inner.Remove(Convert(item));
+
+        bool IDictionary<string, string[]>.Remove(string key) => Inner.Remove(key);
+
+        bool IDictionary<string, string[]>.TryGetValue(string key, out string[] value)
+        {
+            StringValues temp;
+            if (Inner.TryGetValue(key, out temp))
+            {
+                value = temp;
+                return true;
+            }
+            value = default(StringValues);
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Owin/DictionaryStringValuesWrapper.cs
+++ b/src/Microsoft.AspNet.Owin/DictionaryStringValuesWrapper.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.Primitives;
+
+namespace Microsoft.AspNet.Owin
+{
+    internal class DictionaryStringValuesWrapper : IDictionary<string, StringValues>
+    {
+        public DictionaryStringValuesWrapper(IDictionary<string, string[]> inner)
+        {
+            Inner = inner;
+        }
+
+        public readonly IDictionary<string, string[]> Inner;
+
+        private KeyValuePair<string, StringValues> Convert(KeyValuePair<string, string[]> item) => new KeyValuePair<string, StringValues>(item.Key, item.Value);
+
+        private KeyValuePair<string, string[]> Convert(KeyValuePair<string, StringValues> item) => new KeyValuePair<string, string[]>(item.Key, item.Value);
+
+        private StringValues Convert(string[] item) => item;
+
+        private string[] Convert(StringValues item) => item;
+
+        StringValues IDictionary<string, StringValues>.this[string key]
+        {
+            get { return Inner[key]; }
+            set { Inner[key] = value; }
+        }
+
+        int ICollection<KeyValuePair<string, StringValues>>.Count => Inner.Count;
+
+        bool ICollection<KeyValuePair<string, StringValues>>.IsReadOnly => Inner.IsReadOnly;
+
+        ICollection<string> IDictionary<string, StringValues>.Keys => Inner.Keys;
+
+        ICollection<StringValues> IDictionary<string, StringValues>.Values => Inner.Values.Select(Convert).ToList();
+
+        void ICollection<KeyValuePair<string, StringValues>>.Add(KeyValuePair<string, StringValues> item) => Inner.Add(Convert(item));
+
+        void IDictionary<string, StringValues>.Add(string key, StringValues value) => Inner.Add(key, value);
+
+        void ICollection<KeyValuePair<string, StringValues>>.Clear() => Inner.Clear();
+
+        bool ICollection<KeyValuePair<string, StringValues>>.Contains(KeyValuePair<string, StringValues> item) => Inner.Contains(Convert(item));
+
+        bool IDictionary<string, StringValues>.ContainsKey(string key) => Inner.ContainsKey(key);
+
+        void ICollection<KeyValuePair<string, StringValues>>.CopyTo(KeyValuePair<string, StringValues>[] array, int arrayIndex)
+        {
+            foreach (var kv in Inner)
+            {
+                array[arrayIndex++] = Convert(kv);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => Inner.Select(Convert).GetEnumerator();
+
+        IEnumerator<KeyValuePair<string, StringValues>> IEnumerable<KeyValuePair<string, StringValues>>.GetEnumerator() => Inner.Select(Convert).GetEnumerator();
+
+        bool ICollection<KeyValuePair<string, StringValues>>.Remove(KeyValuePair<string, StringValues> item) => Inner.Remove(Convert(item));
+
+        bool IDictionary<string, StringValues>.Remove(string key) => Inner.Remove(key);
+
+        bool IDictionary<string, StringValues>.TryGetValue(string key, out StringValues value)
+        {
+            string[] temp;
+            if (Inner.TryGetValue(key, out temp))
+            {
+                value = temp;
+                return true;
+            }
+            value = default(StringValues);
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
+++ b/src/Microsoft.AspNet.Owin/OwinEnvironment.cs
@@ -56,13 +56,13 @@ namespace Microsoft.AspNet.Owin
                 { OwinConstants.RequestPath, new FeatureMap<IHttpRequestFeature>(feature => feature.Path, () => string.Empty, (feature, value) => feature.Path = Convert.ToString(value)) },
                 { OwinConstants.RequestQueryString, new FeatureMap<IHttpRequestFeature>(feature => Utilities.RemoveQuestionMark(feature.QueryString), () => string.Empty,
                     (feature, value) => feature.QueryString = Utilities.AddQuestionMark(Convert.ToString(value))) },
-                { OwinConstants.RequestHeaders, new FeatureMap<IHttpRequestFeature>(feature => feature.Headers, (feature, value) => feature.Headers = (IDictionary<string, string[]>)value) },
+                { OwinConstants.RequestHeaders, new FeatureMap<IHttpRequestFeature>(feature => Utilities.MakeDictionaryStringArray(feature.Headers), (feature, value) => feature.Headers = Utilities.MakeDictionaryStringValues((IDictionary<string, string[]>)value)) },
                 { OwinConstants.RequestBody, new FeatureMap<IHttpRequestFeature>(feature => feature.Body, () => Stream.Null, (feature, value) => feature.Body = (Stream)value) },
                 { OwinConstants.RequestUser, new FeatureMap<IHttpAuthenticationFeature>(feature => feature.User, () => null, (feature, value) => feature.User = (ClaimsPrincipal)value) },
 
                 { OwinConstants.ResponseStatusCode, new FeatureMap<IHttpResponseFeature>(feature => feature.StatusCode, () => 200, (feature, value) => feature.StatusCode = Convert.ToInt32(value)) },
                 { OwinConstants.ResponseReasonPhrase, new FeatureMap<IHttpResponseFeature>(feature => feature.ReasonPhrase, (feature, value) => feature.ReasonPhrase = Convert.ToString(value)) },
-                { OwinConstants.ResponseHeaders, new FeatureMap<IHttpResponseFeature>(feature => feature.Headers, (feature, value) => feature.Headers = (IDictionary<string, string[]>)value) },
+                { OwinConstants.ResponseHeaders, new FeatureMap<IHttpResponseFeature>(feature => Utilities.MakeDictionaryStringArray(feature.Headers), (feature, value) => feature.Headers = Utilities.MakeDictionaryStringValues((IDictionary<string, string[]>)value)) },
                 { OwinConstants.ResponseBody, new FeatureMap<IHttpResponseFeature>(feature => feature.Body, () => Stream.Null, (feature, value) => feature.Body = (Stream)value) },
                 { OwinConstants.CommonKeys.OnSendingHeaders, new FeatureMap<IHttpResponseFeature>(
                     feature => new Action<Action<object>, object>((cb, state) => {

--- a/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
+++ b/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
@@ -14,8 +14,10 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Http.Features.Authentication;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Owin
 {
@@ -104,10 +106,10 @@ namespace Microsoft.AspNet.Owin
             set { Prop(OwinConstants.RequestQueryString, Utilities.RemoveQuestionMark(value)); }
         }
 
-        IDictionary<string, string[]> IHttpRequestFeature.Headers
+        IDictionary<string, StringValues> IHttpRequestFeature.Headers
         {
-            get { return Prop<IDictionary<string, string[]>>(OwinConstants.RequestHeaders); }
-            set { Prop(OwinConstants.RequestHeaders, value); }
+            get { return Utilities.MakeDictionaryStringValues(Prop<IDictionary<string, string[]>>(OwinConstants.RequestHeaders)); }
+            set { Prop(OwinConstants.RequestHeaders, Utilities.MakeDictionaryStringArray(value)); }
         }
 
         string IHttpRequestIdentifierFeature.TraceIdentifier
@@ -134,10 +136,10 @@ namespace Microsoft.AspNet.Owin
             set { Prop(OwinConstants.ResponseReasonPhrase, value); }
         }
 
-        IDictionary<string, string[]> IHttpResponseFeature.Headers
+        IDictionary<string, StringValues> IHttpResponseFeature.Headers
         {
-            get { return Prop<IDictionary<string, string[]>>(OwinConstants.ResponseHeaders); }
-            set { Prop(OwinConstants.ResponseHeaders, value); }
+            get { return Utilities.MakeDictionaryStringValues(Prop<IDictionary<string, string[]>>(OwinConstants.ResponseHeaders)); }
+            set { Prop(OwinConstants.ResponseHeaders, Utilities.MakeDictionaryStringArray(value)); }
         }
 
         Stream IHttpResponseFeature.Body

--- a/src/Microsoft.AspNet.Owin/Utilities.cs
+++ b/src/Microsoft.AspNet.Owin/Utilities.cs
@@ -1,8 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Security.Principal;
+using Microsoft.AspNet.Http;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Owin
 {
@@ -40,6 +44,26 @@ namespace Microsoft.AspNet.Owin
                 return principal as ClaimsPrincipal;
             }
             return new ClaimsPrincipal(principal);
+        }
+
+        internal static IDictionary<string, StringValues> MakeDictionaryStringValues(IDictionary<string, string[]> dictionary)
+        {
+            var wrapper = dictionary as DictionaryStringArrayWrapper;
+            if (wrapper != null)
+            {
+                return wrapper.Inner;
+            }
+            return new DictionaryStringValuesWrapper(dictionary);
+        }
+
+        internal static IDictionary<string, string[]> MakeDictionaryStringArray(IDictionary<string, StringValues> dictionary)
+        {
+            var wrapper = dictionary as DictionaryStringValuesWrapper;
+            if (wrapper != null)
+            {
+                return wrapper.Inner;
+            }
+            return new DictionaryStringArrayWrapper(dictionary);
         }
     }
 }

--- a/src/Microsoft.AspNet.WebUtilities/FormReader.cs
+++ b/src/Microsoft.AspNet.WebUtilities/FormReader.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.WebUtilities
 {
@@ -150,11 +151,11 @@ namespace Microsoft.AspNet.WebUtilities
         /// </summary>
         /// <param name="text">The HTTP form body to parse.</param>
         /// <returns>The collection containing the parsed HTTP form body.</returns>
-        public static IDictionary<string, string[]> ReadForm(string text)
+        public static IDictionary<string, StringValues> ReadForm(string text)
         {
             var reader = new FormReader(text);
 
-            var accumulator = new KeyValueAccumulator<string, string>(StringComparer.OrdinalIgnoreCase);
+            var accumulator = new KeyValueAccumulator();
             var pair = reader.ReadNextPair();
             while (pair.HasValue)
             {
@@ -170,7 +171,7 @@ namespace Microsoft.AspNet.WebUtilities
         /// </summary>
         /// <param name="stream">The HTTP form body to parse.</param>
         /// <returns>The collection containing the parsed HTTP form body.</returns>
-        public static Task<IDictionary<string, string[]>> ReadFormAsync(Stream stream, CancellationToken cancellationToken = new CancellationToken())
+        public static Task<IDictionary<string, StringValues>> ReadFormAsync(Stream stream, CancellationToken cancellationToken = new CancellationToken())
         {
             return ReadFormAsync(stream, Encoding.UTF8, cancellationToken);
         }
@@ -180,11 +181,11 @@ namespace Microsoft.AspNet.WebUtilities
         /// </summary>
         /// <param name="stream">The HTTP form body to parse.</param>
         /// <returns>The collection containing the parsed HTTP form body.</returns>
-        public static async Task<IDictionary<string, string[]>> ReadFormAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken = new CancellationToken())
+        public static async Task<IDictionary<string, StringValues>> ReadFormAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken = new CancellationToken())
         {
             var reader = new FormReader(stream, encoding);
 
-            var accumulator = new KeyValueAccumulator<string, string>(StringComparer.OrdinalIgnoreCase);
+            var accumulator = new KeyValueAccumulator();
             var pair = await reader.ReadNextPairAsync(cancellationToken);
             while (pair.HasValue)
             {

--- a/src/Microsoft.AspNet.WebUtilities/KeyValueAccumulator.cs
+++ b/src/Microsoft.AspNet.WebUtilities/KeyValueAccumulator.cs
@@ -1,38 +1,37 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
-using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.WebUtilities
 {
-    public class KeyValueAccumulator<TKey, TValue>
+    public class KeyValueAccumulator
     {
-        private Dictionary<TKey, List<TValue>> _accumulator;
-        IEqualityComparer<TKey> _comparer;
+        private Dictionary<string, List<string>> _accumulator;
 
-        public KeyValueAccumulator([NotNull] IEqualityComparer<TKey> comparer)
+        public KeyValueAccumulator()
         {
-            _comparer = comparer;
-            _accumulator = new Dictionary<TKey, List<TValue>>(comparer);
+            _accumulator = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         }
 
-        public void Append(TKey key, TValue value)
+        public void Append(string key, string value)
         {
-            List<TValue> values;
+            List<string> values;
             if (_accumulator.TryGetValue(key, out values))
             {
                 values.Add(value);
             }
             else
             {
-                _accumulator[key] = new List<TValue>(1) { value };
+                _accumulator[key] = new List<string>(1) { value };
             }
         }
 
-        public IDictionary<TKey, TValue[]> GetResults()
+        public IDictionary<string, StringValues> GetResults()
         {
-            var results = new Dictionary<TKey, TValue[]>(_comparer);
+            var results = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
             foreach (var kv in _accumulator)
             {
                 results.Add(kv.Key, kv.Value.ToArray());

--- a/src/Microsoft.AspNet.WebUtilities/MultipartReader.cs
+++ b/src/Microsoft.AspNet.WebUtilities/MultipartReader.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.WebUtilities
 {
@@ -64,10 +65,10 @@ namespace Microsoft.AspNet.WebUtilities
             return new MultipartSection() { Headers = headers, Body = _currentStream, BaseStreamOffset = baseStreamOffset };
         }
 
-        private async Task<IDictionary<string, string[]>> ReadHeadersAsync(CancellationToken cancellationToken)
+        private async Task<IDictionary<string, StringValues>> ReadHeadersAsync(CancellationToken cancellationToken)
         {
             int totalSize = 0;
-            var accumulator = new KeyValueAccumulator<string, string>(StringComparer.OrdinalIgnoreCase);
+            var accumulator = new KeyValueAccumulator();
             var line = await _stream.ReadLineAsync(HeaderLengthLimit, cancellationToken);
             while (!string.IsNullOrEmpty(line))
             {

--- a/src/Microsoft.AspNet.WebUtilities/MultipartSection.cs
+++ b/src/Microsoft.AspNet.WebUtilities/MultipartSection.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.WebUtilities
 {
@@ -12,10 +13,10 @@ namespace Microsoft.AspNet.WebUtilities
         {
             get
             {
-                string[] values;
+                StringValues values;
                 if (Headers.TryGetValue("Content-Type", out values))
                 {
-                    return string.Join(", ", values);
+                    return values;
                 }
                 return null;
             }
@@ -25,16 +26,16 @@ namespace Microsoft.AspNet.WebUtilities
         {
             get
             {
-                string[] values;
+                StringValues values;
                 if (Headers.TryGetValue("Content-Disposition", out values))
                 {
-                    return string.Join(", ", values);
+                    return values;
                 }
                 return null;
             }
         }
 
-        public IDictionary<string, string[]> Headers { get; set; }
+        public IDictionary<string, StringValues> Headers { get; set; }
 
         public Stream Body { get; set; }
 

--- a/src/Microsoft.AspNet.WebUtilities/QueryHelpers.cs
+++ b/src/Microsoft.AspNet.WebUtilities/QueryHelpers.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Primitives;
 using Microsoft.Framework.WebEncoders;
 
 namespace Microsoft.AspNet.WebUtilities
@@ -72,13 +73,13 @@ namespace Microsoft.AspNet.WebUtilities
         /// </summary>
         /// <param name="text">The raw query string value, with or without the leading '?'.</param>
         /// <returns>A collection of parsed keys and values.</returns>
-        public static IDictionary<string, string[]> ParseQuery(string queryString)
+        public static IDictionary<string, StringValues> ParseQuery(string queryString)
         {
             if (!string.IsNullOrEmpty(queryString) && queryString[0] == '?')
             {
                 queryString = queryString.Substring(1);
             }
-            var accumulator = new KeyValueAccumulator<string, string>(StringComparer.OrdinalIgnoreCase);
+            var accumulator = new KeyValueAccumulator();
 
             int textLength = queryString.Length;
             int equalIndex = queryString.IndexOf('=');

--- a/src/Microsoft.AspNet.WebUtilities/project.json
+++ b/src/Microsoft.AspNet.WebUtilities/project.json
@@ -7,13 +7,13 @@
     },
     "dependencies": {
         "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
+        "Microsoft.Framework.Primitives": "1.0.0-*",
         "Microsoft.Framework.WebEncoders.Core": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
-                "System.Collections": "4.0.11-beta-*",
                 "System.Diagnostics.Debug": "4.0.11-beta-*",
                 "System.IO": "4.0.11-beta-*",
                 "System.IO.FileSystem": "4.0.1-beta-*",

--- a/src/Microsoft.Framework.Primitives/Microsoft.Framework.Primitives.xproj
+++ b/src/Microsoft.Framework.Primitives/Microsoft.Framework.Primitives.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>e5faccd4-6327-43aa-80a9-ae6f4a3bfe6a</ProjectGuid>
+    <RootNamespace>Microsoft.AspNet.Primitives</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Framework.Primitives/StringValues.cs
+++ b/src/Microsoft.Framework.Primitives/StringValues.cs
@@ -1,0 +1,233 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Framework.Primitives
+{
+    /// <summary>
+    /// Represents zero/null, one, or many strings in an efficient way.
+    /// </summary>
+    public struct StringValues : IList<string>
+    {
+        private static readonly string[] EmptyArray = new string[0];
+        public static readonly StringValues Empty = new StringValues(EmptyArray);
+
+        private readonly string _value;
+        private readonly string[] _values;
+
+        public StringValues(string value)
+        {
+            _value = value;
+            _values = null;
+        }
+
+        public StringValues(string[] values)
+        {
+            _value = null;
+            _values = values;
+        }
+
+        public static implicit operator StringValues(string value)
+        {
+            return new StringValues(value);
+        }
+
+        public static implicit operator StringValues(string[] values)
+        {
+            return new StringValues(values);
+        }
+
+        public static implicit operator string (StringValues values)
+        {
+            return values.GetStringValue();
+        }
+
+        public static implicit operator string[] (StringValues value)
+        {
+            return value.GetArrayValue();
+        }
+
+        public int Count => _values?.Length ?? (_value != null ? 1 : 0);
+
+        bool ICollection<string>.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        string IList<string>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
+
+        public string this[int key]
+        {
+            get
+            {
+                if (_values != null)
+                {
+                    return _values[key]; // may throw
+                }
+                if (key == 0 && _value != null)
+                {
+                    return _value;
+                }
+                return EmptyArray[0]; // throws
+            }
+        }
+
+        public override string ToString()
+        {
+            return GetStringValue() ?? string.Empty;
+        }
+
+        private string GetStringValue()
+        {
+            if (_values == null)
+            {
+                return _value;
+            }
+            switch (_values.Length)
+            {
+                case 0: return null;
+                case 1: return _values[0];
+                default: return string.Join(",", _values);
+            }
+        }
+
+        public string[] ToArray()
+        {
+            return GetArrayValue() ?? EmptyArray;
+        }
+
+        private string[] GetArrayValue()
+        {
+            if (_value != null)
+            {
+                return new[] { _value };
+            }
+            return _values;
+        }
+
+        int IList<string>.IndexOf(string item)
+        {
+            var index = 0;
+            foreach (var value in this)
+            {
+                if (string.Equals(value, item, StringComparison.Ordinal))
+                {
+                    return index;
+                }
+                index += 1;
+            }
+            return -1;
+        }
+
+        bool ICollection<string>.Contains(string item)
+        {
+            return ((IList<string>)this).IndexOf(item) >= 0;
+        }
+
+        void ICollection<string>.CopyTo(string[] array, int arrayIndex)
+        {
+            for(int i = 0; i < Count; i++)
+            {
+                array[arrayIndex + i] = this[i];
+            }
+        }
+
+        void ICollection<string>.Add(string item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList<string>.Insert(int index, string item)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool ICollection<string>.Remove(string item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList<string>.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection<string>.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable<string>)this).GetEnumerator();
+        }
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
+        {
+            if (Count == 0)
+            {
+                yield break;
+            }
+            if (_values == null)
+            {
+                yield return _value;
+            }
+            else
+            {
+                for (int i = 0; i < _values.Length; i++)
+                {
+                    yield return _values[i];
+                }
+            }
+        }
+
+        public static bool IsNullOrEmpty(StringValues value)
+        {
+            if (value._values == null)
+            {
+                return string.IsNullOrEmpty(value._value);
+            }
+            switch (value._values.Length)
+            {
+                case 0: return true;
+                case 1: return string.IsNullOrEmpty(value._values[0]);
+                default: return false;
+            }
+        }
+
+        public static StringValues Concat(StringValues values1, StringValues values2)
+        {
+            var count1 = values1.Count;
+            var count2 = values2.Count;
+
+            if (count1 == 0)
+            {
+                return values2;
+            }
+
+            if (count2 == 0)
+            {
+                return values1;
+            }
+
+            var combined = new string[count1 + count2];
+            var index = 0;
+            foreach (var value in values1)
+            {
+                combined[index++] = value;
+            }
+            foreach (var value in values2)
+            {
+                combined[index++] = value;
+            }
+            return new StringValues(combined);
+        }
+    }
+}

--- a/src/Microsoft.Framework.Primitives/project.json
+++ b/src/Microsoft.Framework.Primitives/project.json
@@ -1,0 +1,23 @@
+﻿{
+  "version": "1.0.0-*",
+  "description": "Contains primitive types such as StringValues.",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/aspnet/httpabstractions"
+  },
+  "dependencies": {
+    "Microsoft.Framework.NotNullAttribute.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    }
+  },
+  "frameworks": {
+    "net451": { },
+    "dnx451": { },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Collections": "4.0.11-beta-*"
+      }
+    }
+  }
+}

--- a/test/Microsoft.AspNet.Http.Tests/DefaultHttpRequestTests.cs
+++ b/test/Microsoft.AspNet.Http.Tests/DefaultHttpRequestTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.AspNet.Http.Features;
+using Microsoft.Framework.Primitives;
 using Xunit;
 
 namespace Microsoft.AspNet.Http.Internal
@@ -64,9 +65,9 @@ namespace Microsoft.AspNet.Http.Internal
             // Arrange
             const string expected = "localhost:9001";
 
-            var headers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
             {
-                { "Host", new string[] { expected } },
+                { "Host", expected },
             };
 
             var request = CreateRequest(headers);
@@ -84,9 +85,9 @@ namespace Microsoft.AspNet.Http.Internal
             // Arrange
             const string expected = "löcalhöst";
 
-            var headers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
             {
-                { "Host", new string[]{ "xn--lcalhst-90ae" } },
+                { "Host", "xn--lcalhst-90ae" },
             };
 
             var request = CreateRequest(headers);
@@ -104,7 +105,7 @@ namespace Microsoft.AspNet.Http.Internal
             // Arrange
             const string expected = "xn--lcalhst-90ae";
 
-            var headers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
 
             var request = CreateRequest(headers);
 
@@ -149,9 +150,9 @@ namespace Microsoft.AspNet.Http.Internal
             Assert.Equal("value0", query1["name0"]);
             Assert.Equal("value1", query1["name1"]);
 
-            var query2 = new ReadableStringCollection(new Dictionary<string, string[]>()
+            var query2 = new ReadableStringCollection(new Dictionary<string, StringValues>()
             {
-                { "name2", new[] { "value2" } }
+                { "name2", "value2" }
             });
 
             request.Query = query2;
@@ -164,30 +165,30 @@ namespace Microsoft.AspNet.Http.Internal
         public void Cookies_GetAndSet()
         {
             var request = new DefaultHttpContext().Request;
-            var cookieHeaders = request.Headers.GetValues("Cookie");
-            Assert.Null(cookieHeaders);
+            var cookieHeaders = request.Headers["Cookie"];
+            Assert.Equal(0, cookieHeaders.Count);
             var cookies0 = request.Cookies;
             Assert.Equal(0, cookies0.Count);
 
-            request.Headers.SetValues("Cookie", new[] { "name0=value0", "name1=value1" });
+            request.Headers["Cookie"] = new[] { "name0=value0", "name1=value1" };
             var cookies1 = request.Cookies;
             Assert.Same(cookies0, cookies1);
             Assert.Equal(2, cookies1.Count);
             Assert.Equal("value0", cookies1["name0"]);
             Assert.Equal("value1", cookies1["name1"]);
 
-            var cookies2 = new ReadableStringCollection(new Dictionary<string, string[]>()
+            var cookies2 = new ReadableStringCollection(new Dictionary<string, StringValues>()
             {
-                { "name2", new[] { "value2" } }
+                { "name2", "value2" }
             });
             request.Cookies = cookies2;
             Assert.Same(cookies2, request.Cookies);
             Assert.Equal("value2", request.Cookies["name2"]);
-            cookieHeaders = request.Headers.GetValues("Cookie");
+            cookieHeaders = request.Headers["Cookie"];
             Assert.Equal(new[] { "name2=value2" }, cookieHeaders);
         }
 
-        private static HttpRequest CreateRequest(IDictionary<string, string[]> headers)
+        private static HttpRequest CreateRequest(IDictionary<string, StringValues> headers)
         {
             var context = new DefaultHttpContext();
             context.GetFeature<IHttpRequestFeature>().Headers = headers;
@@ -216,10 +217,10 @@ namespace Microsoft.AspNet.Http.Internal
 
         private static HttpRequest GetRequestWithHeader(string headerName, string headerValue)
         {
-            var headers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
             if (headerValue != null)
             {
-                headers.Add(headerName, new[] { headerValue });
+                headers.Add(headerName, headerValue);
             }
 
             return CreateRequest(headers);

--- a/test/Microsoft.AspNet.Http.Tests/HeaderDictionaryTests.cs
+++ b/test/Microsoft.AspNet.Http.Tests/HeaderDictionaryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Framework.Primitives;
 using Xunit;
 
 namespace Microsoft.AspNet.Http.Internal
@@ -13,9 +14,9 @@ namespace Microsoft.AspNet.Http.Internal
         public void PropertiesAreAccessible()
         {
             var headers = new HeaderDictionary(
-                new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+                new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "Header1", new[] { "Value1" } }
+                    { "Header1", "Value1" }
                 });
 
             Assert.Equal(1, headers.Count);
@@ -23,8 +24,7 @@ namespace Microsoft.AspNet.Http.Internal
             Assert.True(headers.ContainsKey("header1"));
             Assert.False(headers.ContainsKey("header2"));
             Assert.Equal("Value1", headers["header1"]);
-            Assert.Equal("Value1", headers.Get("header1"));
-            Assert.Equal(new[] { "Value1" }, headers.GetValues("header1"));
+            Assert.Equal(new[] { "Value1" }, headers["header1"].ToArray());
         }
     }
 }

--- a/test/Microsoft.Framework.Primitives.Tests/Microsoft.Framework.Primitives.Tests.xproj
+++ b/test/Microsoft.Framework.Primitives.Tests/Microsoft.Framework.Primitives.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>61f72e92-b3ae-4a10-b838-44f80aed40ae</ProjectGuid>
+    <RootNamespace>Microsoft.AspNet.Primitives.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.Framework.Primitives.Tests/StringValuesTests.cs
+++ b/test/Microsoft.Framework.Primitives.Tests/StringValuesTests.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Framework.Primitives
+{
+    public class StringValuesTests
+    {
+        [Fact]
+        public void IsReadOnly_True()
+        {
+            var stringValues = new StringValues();
+            Assert.True(((IList<string>)stringValues).IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => ((IList<string>)stringValues)[0] = string.Empty);
+            Assert.Throws<NotSupportedException>(() => ((ICollection<string>)stringValues).Add(string.Empty));
+            Assert.Throws<NotSupportedException>(() => ((IList<string>)stringValues).Insert(0, string.Empty));
+            Assert.Throws<NotSupportedException>(() => ((ICollection<string>)stringValues).Remove(string.Empty));
+            Assert.Throws<NotSupportedException>(() => ((IList<string>)stringValues).RemoveAt(0));
+            Assert.Throws<NotSupportedException>(() => ((ICollection<string>)stringValues).Clear());
+        }
+
+        [Fact]
+        public void DefaultConstructor_ExpectedValues()
+        {
+            var stringValues = new StringValues();
+            Assert.Equal(0, stringValues.Count);
+            Assert.Equal((string)null, stringValues);
+            Assert.Equal(new string[0], stringValues.ToArray());
+
+            Assert.True(StringValues.IsNullOrEmpty(stringValues));
+            Assert.Throws<IndexOutOfRangeException>(() => stringValues[0]);
+            Assert.Equal(string.Empty, stringValues.ToString());
+            Assert.Equal(-1, ((IList<string>)stringValues).IndexOf(string.Empty));
+            Assert.Equal(0, stringValues.Count());
+        }
+
+        [Fact]
+        public void Constructor_NullStringValue_ExpectedValues()
+        {
+            var stringValues = new StringValues((string)null);
+            Assert.Equal(0, stringValues.Count);
+            Assert.Null((string)stringValues);
+            Assert.Equal(string.Empty, stringValues.ToString());
+            Assert.Null((string[])stringValues);
+            Assert.Equal(new string[0], stringValues.ToArray());
+
+            Assert.True(StringValues.IsNullOrEmpty(stringValues));
+            Assert.Throws<IndexOutOfRangeException>(() => stringValues[0]);
+            Assert.Equal(-1, ((IList<string>)stringValues).IndexOf(string.Empty));
+            Assert.Equal(0, stringValues.Count());
+        }
+
+        [Fact]
+        public void Constructor_NullStringArray_ExpectedValues()
+        {
+            var stringValues = new StringValues((string[])null);
+            Assert.Equal(0, stringValues.Count);
+            Assert.Null((string)stringValues);
+            Assert.Equal(string.Empty, stringValues.ToString());
+            Assert.Null((string[])stringValues);
+            Assert.Equal(new string[0], stringValues.ToArray());
+
+            Assert.True(StringValues.IsNullOrEmpty(stringValues));
+            Assert.Throws<IndexOutOfRangeException>(() => stringValues[0]);
+            Assert.Equal(string.Empty, stringValues.ToString());
+            Assert.Equal(-1, ((IList<string>)stringValues).IndexOf(string.Empty));
+            Assert.Equal(0, stringValues.Count());
+        }
+
+        [Fact]
+        public void ImplicitStringConverter_Works()
+        {
+            string nullString = null;
+            StringValues stringValues = nullString;
+            Assert.Equal(0, stringValues.Count);
+            Assert.Null((string)stringValues);
+            Assert.Null((string[])stringValues);
+
+            string aString = "abc";
+            stringValues = aString;
+            Assert.Equal(1, stringValues.Count);
+            Assert.Equal(aString, stringValues);
+            Assert.Equal(aString, stringValues[0]);
+            Assert.Equal<string[]>(new string[] { aString }, stringValues);
+        }
+
+        [Fact]
+        public void ImplicitStringArrayConverter_Works()
+        {
+            string[] nullStringArray = null;
+            StringValues stringValues = nullStringArray;
+            Assert.Equal(0, stringValues.Count);
+            Assert.Null((string)stringValues);
+            Assert.Null((string[])stringValues);
+
+            string aString = "abc";
+            string[] aStringArray = new[] { aString };
+            stringValues = aStringArray;
+            Assert.Equal(1, stringValues.Count);
+            Assert.Equal(aString, stringValues);
+            Assert.Equal(aString, stringValues[0]);
+            Assert.Equal<string[]>(aStringArray, stringValues);
+
+            aString = "abc";
+            string bString = "bcd";
+            aStringArray = new[] { aString, bString };
+            stringValues = aStringArray;
+            Assert.Equal(2, stringValues.Count);
+            Assert.Equal("abc,bcd", stringValues);
+            Assert.Equal<string[]>(aStringArray, stringValues);
+        }
+    }
+}

--- a/test/Microsoft.Framework.Primitives.Tests/project.json
+++ b/test/Microsoft.Framework.Primitives.Tests/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "dependencies": {
+    "Microsoft.Framework.Primitives": "1.0.0-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  },
+  "commands": {
+    "test": "xunit.runner.aspnet"
+  },
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  }
+}


### PR DESCRIPTION
#361
Open issues:
- Name and location of the package containing StringValues. It needs to make sense to reference even from Microsoft.Net.Http.Server (WebListener's low level API without Asp.Net dependencies). Microsoft.AspNet.Primitives is just a placeholder.

Related breaking changes:
- IHeaderDictionary:
 - Removal of AppendValues, Get*, and Set*
 - Append now functions like AppendValues instead of AppendCommaSeperatedValues.
- IReadableStringCollection
 - Removal of Get*, use the indexer instead.

Here are some of the necessary changes in downstream repos. Please use them only as references to evaluate this PR, lets avoid full reviews on them until we have settled open issues on this one.
- https://github.com/aspnet/Hosting/commit/49b8b293027e9432fb6c44cd6c43d0f875b7d814
- https://github.com/aspnet/Helios/commit/724cb5823199d93987a4cb97f8fdfffbb498bde4
- https://github.com/aspnet/WebListener/commit/d858bf73fd2f8477858e47f7280a1f6785e9b0a5
- https://github.com/aspnet/KestrelHttpServer/commit/2abc40692577227ad0599b19915c5885ac979338
- https://github.com/aspnet/Security/commit/25af3ee9f71447f5de42add2d4aa8bce7cfb7ba1
- https://github.com/aspnet/Mvc/commit/6331a9c1f4a2e6fff43a2535976ce2dde43bcaa6

@lodejard @davidfowl @muratg @rynowak @halter73 @Eilon 
