### PR TITLE
Add AppendEncoded to the builder

### DIFF
--- a/src/Microsoft.AspNet.Html.Abstractions/IHtmlContentBuilder.cs
+++ b/src/Microsoft.AspNet.Html.Abstractions/IHtmlContentBuilder.cs
@@ -24,6 +24,14 @@ namespace Microsoft.AspNet.Html.Abstractions
         IHtmlContentBuilder Append(string unencoded);
 
         /// <summary>
+        /// Appends an HTML encoded <see cref="string"/> value. The value is treated as HTML encoded as-provided, and
+        /// no further encoding will be performed.
+        /// </summary>
+        /// <param name="content">The HTML encoded <see cref="string"/> to append.</param>
+        /// <returns>The <see cref="IHtmlContentBuilder"/>.</returns>
+        IHtmlContentBuilder AppendEncoded(string encoded);
+
+        /// <summary>
         /// Clears the content.
         /// </summary>
         void Clear();


### PR DESCRIPTION
This is needed because a builder may have an optimized path for an
unencoded string. There's also no 'common' encoded string implementation
so it's much more straightforward to put this on the interface.