### PR TITLE
Remove FeatureReference indirection

### DIFF
--- a/src/Microsoft.AspNet.Http/Features/FeatureHelpers.cs
+++ b/src/Microsoft.AspNet.Http/Features/FeatureHelpers.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Http.Features
+{
+    internal sealed class FeatureHelpers
+    {
+        public static T GetAndCache<T>(
+            IFeatureCache cache, 
+            IFeatureCollection features, 
+            ref T cachedObject)
+        {
+            cache.CheckFeaturesRevision();
+
+            T obj = cachedObject;
+            if (obj == null)
+            {
+                obj = features.Get<T>();
+                cachedObject = obj;
+            }
+            return obj;
+        }
+
+        public static T GetOrCreateAndCache<T>(
+            IFeatureCache cache, 
+            IFeatureCollection features,
+            Func<T> factory,
+            ref T cachedObject)
+        {
+            cache.CheckFeaturesRevision();
+
+            T obj = cachedObject;
+            if (obj == null)
+            {
+                obj = features.Get<T>();
+                if (obj == null)
+                {
+                    obj = factory();
+                    cachedObject = obj;
+                    features.Set(obj);
+                }
+            }
+            return obj;
+        }
+        
+        public static T GetOrCreateAndCache<T>(
+            IFeatureCache cache,
+            IFeatureCollection features, 
+            Func<IFeatureCollection, T> factory,
+            ref T cachedObject)
+        {
+            cache.CheckFeaturesRevision();
+
+            T obj = cachedObject;
+            if (obj == null)
+            {
+                obj = features.Get<T>();
+                if (obj == null)
+                {
+                    obj = factory(features);
+                    cachedObject = obj;
+                    features.Set(obj);
+                }
+            }
+            return obj;
+        }
+
+        public static T GetOrCreateAndCache<T>(
+            IFeatureCache cache,
+            IFeatureCollection features,
+            HttpRequest request,
+            Func<HttpRequest, T> factory,
+            ref T cachedObject)
+        {
+            cache.CheckFeaturesRevision();
+
+            T obj = cachedObject;
+            if (obj == null)
+            {
+                obj = features.Get<T>();
+                if (obj == null)
+                {
+                    obj = factory(request);
+                    cachedObject = obj;
+                    features.Set(obj);
+                }
+            }
+            return obj;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Http/Features/IFeatureCache.cs
+++ b/src/Microsoft.AspNet.Http/Features/IFeatureCache.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Http.Features
+{
+    internal interface IFeatureCache
+    {
+        void CheckFeaturesRevision();
+    }
+}

--- a/src/Microsoft.AspNet.Http/Features/QueryFeature.cs
+++ b/src/Microsoft.AspNet.Http/Features/QueryFeature.cs
@@ -9,10 +9,12 @@ using Microsoft.Framework.Primitives;
 
 namespace Microsoft.AspNet.Http.Features.Internal
 {
-    public class QueryFeature : IQueryFeature
+    public class QueryFeature : IQueryFeature, IFeatureCache
     {
         private readonly IFeatureCollection _features;
-        private FeatureReference<IHttpRequestFeature> _request = FeatureReference<IHttpRequestFeature>.Default;
+        private int _cachedFeaturesRevision = -1;
+
+        private IHttpRequestFeature _request;
 
         private string _original;
         private IReadableStringCollection _parsedValues;
@@ -46,6 +48,20 @@ namespace Microsoft.AspNet.Http.Features.Internal
             _features = features;
         }
 
+        void IFeatureCache.CheckFeaturesRevision()
+        {
+            if (_cachedFeaturesRevision != _features.Revision)
+            {
+                _request = null;
+                _cachedFeaturesRevision = _features.Revision;
+            }
+        }
+
+        private IHttpRequestFeature HttpRequestFeature
+        {
+            get { return FeatureHelpers.GetAndCache(this, _features, ref _request); }
+        }
+
         public IReadableStringCollection Query
         {
             get
@@ -55,7 +71,7 @@ namespace Microsoft.AspNet.Http.Features.Internal
                     return _parsedValues ?? ReadableStringCollection.Empty;
                 }
 
-                var current = _request.Fetch(_features).QueryString;
+                var current = HttpRequestFeature.QueryString;
                 if (_parsedValues == null || !string.Equals(_original, current, StringComparison.Ordinal))
                 {
                     _original = current;
@@ -71,12 +87,12 @@ namespace Microsoft.AspNet.Http.Features.Internal
                     if (value == null)
                     {
                         _original = string.Empty;
-                        _request.Fetch(_features).QueryString = string.Empty;
+                        HttpRequestFeature.QueryString = string.Empty;
                     }
                     else
                     {
                         _original = QueryString.Create(_parsedValues).ToString();
-                        _request.Fetch(_features).QueryString = _original;
+                        HttpRequestFeature.QueryString = _original;
                     }
                 }
             }


### PR DESCRIPTION
~~Is more code~~ Is greatly improved in recent incarnation.

Doesn't cause any extra casting; shouldn't be extra instructions executed; cuts ```CreateHttpContext``` allocation by 17.5%

From 1824 kB per 4k requests

![logging-scope](http://aoa.blob.core.windows.net/aspnet/logging-off.png)

To 1504 kB per 4k requests

![logging-scope-prev](http://aoa.blob.core.windows.net/aspnet/featurerequest-remove.png)

So down by 320 kB per 4k requests; as similar saving to the ```AsyncLocal``` [change in coreclr](https://github.com/dotnet/coreclr/pull/1629)