### PR TITLE
String performance improvements on top of #411

### DIFF
--- a/src/Microsoft.AspNet.Http.Abstractions/FragmentString.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/FragmentString.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNet.Http
             string fragmentValue = uri.GetComponents(UriComponents.Fragment, UriFormat.UriEscaped);
             if (!string.IsNullOrEmpty(fragmentValue))
             {
-                fragmentValue = $"#{fragmentValue}";
+                fragmentValue = "#" + fragmentValue;
             }
             return new FragmentString(fragmentValue);
         }

--- a/src/Microsoft.AspNet.Http.Extensions/UriHelper.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/UriHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Http.Extensions
             FragmentString fragment = new FragmentString())
         {
             string combinePath = (pathBase.HasValue || path.HasValue) ? (pathBase + path).ToString() : "/";
-            return $"{combinePath}{query.ToString()}{fragment.ToString()}";
+            return combinePath + query.ToString() + fragment.ToString();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Http/ResponseCookies.cs
+++ b/src/Microsoft.AspNet.Http/ResponseCookies.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// <param name="key"></param>
         public void Delete(string key)
         {
-            var encodedKeyPlusEquals = $"{UrlEncoder.Default.Encode(key)}=";
+            var encodedKeyPlusEquals = UrlEncoder.Default.Encode(key) + "=";
             Func<string, string, bool> predicate = (value, encKeyPlusEquals) => value.StartsWith(encKeyPlusEquals, StringComparison.OrdinalIgnoreCase);
 
             StringValues deleteCookies = $"{encodedKeyPlusEquals}; expires=Thu, 01-Jan-1970 00:00:00 GMT";
@@ -124,7 +124,7 @@ namespace Microsoft.AspNet.Http.Internal
                 throw new ArgumentNullException(nameof(options));
             }
             
-            var encodedKeyPlusEquals = $"{UrlEncoder.Default.Encode(key)}=";
+            var encodedKeyPlusEquals = UrlEncoder.Default.Encode(key) + "=";
             bool domainHasValue = !string.IsNullOrEmpty(options.Domain);
             bool pathHasValue = !string.IsNullOrEmpty(options.Path);
 

--- a/src/Microsoft.AspNet.WebUtilities/QueryHelpers.cs
+++ b/src/Microsoft.AspNet.WebUtilities/QueryHelpers.cs
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.WebUtilities
         /// <summary>
         /// Parse a query string into its component key and value parts.
         /// </summary>
-        /// <param name="text">The raw query string value, with or without the leading '?'.</param>
+        /// <param name="queryString">The raw query string value, with or without the leading '?'.</param>
         /// <returns>A collection of parsed keys and values.</returns>
         public static Dictionary<string, StringValues> ParseQuery(string queryString)
         {
@@ -123,7 +123,7 @@ namespace Microsoft.AspNet.WebUtilities
         /// <summary>
         /// Parse a query string into its component key and value parts.
         /// </summary>
-        /// <param name="text">The raw query string value, with or without the leading '?'.</param>
+        /// <param name="queryString">The raw query string value, with or without the leading '?'.</param>
         /// <returns>A collection of parsed keys and values, null if there are no entries.</returns>
         public static Dictionary<string, StringValues> ParseNullableQuery(string queryString)
         {
@@ -135,7 +135,7 @@ namespace Microsoft.AspNet.WebUtilities
             }
 
             int scanIndex = 0;
-            if (!string.IsNullOrEmpty(queryString) && queryString[0] == '?')
+            if (queryString[0] == '?')
             {
                 scanIndex = 1;
             }


### PR DESCRIPTION
This adds additional performance improvements (namely string.Concat overloads) for a few cases. It also eliminates an extra check inside QueryHelper.