### PR TITLE
C#6 Cleanup & Optimizations

### DIFF
--- a/src/Microsoft.AspNet.Http.Abstractions/IFormCollection.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/IFormCollection.cs
@@ -88,7 +88,6 @@ namespace Microsoft.AspNet.Http
         /// <summary>
         /// The file collection sent with the request.
         /// </summary>
-        /// <param name="key"></param>
         /// <returns>The files included with the request.</returns>
         IFormFileCollection Files { get; }
     }

--- a/src/Microsoft.AspNet.Http.Abstractions/PathString.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/PathString.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Text.Encodings.Web;
 
 namespace Microsoft.AspNet.Http
@@ -17,7 +16,7 @@ namespace Microsoft.AspNet.Http
         /// <summary>
         /// Represents the empty path. This field is read-only.
         /// </summary>
-        public static readonly PathString Empty = new PathString(String.Empty);
+        public static readonly PathString Empty = new PathString(string.Empty);
 
         private readonly string _value;
 

--- a/src/Microsoft.AspNet.Http.Abstractions/QueryString.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/QueryString.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Http
         /// <summary>
         /// Represents the empty query string. This field is read-only.
         /// </summary>
-        public static readonly QueryString Empty = new QueryString(String.Empty);
+        public static readonly QueryString Empty = new QueryString(string.Empty);
 
         private readonly string _value;
 
@@ -84,7 +84,7 @@ namespace Microsoft.AspNet.Http
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1057:StringUriOverloadsCallSystemUriOverloads", Justification = "Delimiter characters ? and # must be escaped by this method instead of truncating the value")]
         public static QueryString FromUriComponent(string uriComponent)
         {
-            if (String.IsNullOrEmpty(uriComponent))
+            if (string.IsNullOrEmpty(uriComponent))
             {
                 return new QueryString(string.Empty);
             }
@@ -231,7 +231,7 @@ namespace Microsoft.AspNet.Http
 
         public override int GetHashCode()
         {
-            return (_value != null ? _value.GetHashCode() : 0);
+            return _value?.GetHashCode() ?? 0;
         }
 
         public static bool operator ==(QueryString left, QueryString right)

--- a/src/Microsoft.AspNet.Http.Extensions/RequestHeaders.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/RequestHeaders.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Http.Extensions;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Headers

--- a/src/Microsoft.AspNet.Http/FormCollection.cs
+++ b/src/Microsoft.AspNet.Http/FormCollection.cs
@@ -83,11 +83,7 @@ namespace Microsoft.AspNet.Http.Internal
         {
             get
             {
-                if (Store == null)
-                {
-                    return 0;
-                }
-                return Store.Count;
+                return Store?.Count ?? 0;
             }
         }
 

--- a/src/Microsoft.AspNet.Http/HeaderDictionary.cs
+++ b/src/Microsoft.AspNet.Http/HeaderDictionary.cs
@@ -72,12 +72,7 @@ namespace Microsoft.AspNet.Http.Internal
 
                 if (StringValues.IsNullOrEmpty(value))
                 {
-                    if (Store == null)
-                    {
-                        return;
-                    }
-
-                    Store.Remove(key);
+                    Store?.Remove(key);
                 }
                 else
                 {
@@ -110,11 +105,7 @@ namespace Microsoft.AspNet.Http.Internal
         {
             get
             {
-                if (Store == null)
-                {
-                    return 0;
-                }
-                return Store.Count;
+                return Store?.Count ?? 0;
             }
         }
 
@@ -195,11 +186,7 @@ namespace Microsoft.AspNet.Http.Internal
         /// </summary>
         public void Clear()
         {
-            if (Store == null)
-            {
-                return;
-            }
-            Store.Clear();
+            Store?.Clear();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Http/HttpContextAccessor.cs
+++ b/src/Microsoft.AspNet.Http/HttpContextAccessor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Http.Internal
             get
             {
                 var handle = CallContext.LogicalGetData(LogicalDataKey) as ObjectHandle;
-                return handle != null ? handle.Unwrap() as HttpContext : null;
+                return handle?.Unwrap() as HttpContext;
             }
             set
             {

--- a/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
+++ b/src/Microsoft.AspNet.Owin/OwinFeatureCollection.cs
@@ -17,7 +17,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Http.Features.Authentication;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNet.Owin
 {
@@ -45,14 +44,11 @@ namespace Microsoft.AspNet.Owin
             SupportsWebSockets = true;
 
             var register = Prop<Action<Action<object>, object>>(OwinConstants.CommonKeys.OnSendingHeaders);
-            if (register != null)
+            register?.Invoke(state =>
             {
-                register(state =>
-                {
-                    var collection = (OwinFeatureCollection)state;
-                    collection._headersSent = true;
-                }, this);
-            }
+                var collection = (OwinFeatureCollection)state;
+                collection._headersSent = true;
+            }, this);
         }
 
         T Prop<T>(string key)

--- a/src/Microsoft.AspNet.Owin/WebSockets/OwinWebSocketAcceptAdapter.cs
+++ b/src/Microsoft.AspNet.Owin/WebSockets/OwinWebSocketAcceptAdapter.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Owin
                 options = acceptContext.Options;
                 _subProtocol = acceptContext.SubProtocol;
             }
-            else if (context != null && context.SubProtocol != null)
+            else if (context?.SubProtocol != null)
             {
                 options = new Dictionary<string, object>(1)
                 {

--- a/src/Microsoft.AspNet.WebUtilities/WebEncoders.cs
+++ b/src/Microsoft.AspNet.WebUtilities/WebEncoders.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNet.WebUtilities
             // Special-case empty input
             if (count == 0)
             {
-                return String.Empty;
+                return string.Empty;
             }
 
             // We're going to use base64url encoding with no padding characters.

--- a/src/Microsoft.Net.Http.Headers/BaseHeaderParser.cs
+++ b/src/Microsoft.Net.Http.Headers/BaseHeaderParser.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Net.Http.Headers
                 return SupportsMultipleValues;
             }
 
-            T result = default(T);
+            T result;
             var length = GetParsedValueLength(value, current, out result);
 
             if (length == 0)

--- a/src/Microsoft.Net.Http.Headers/CacheControlHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/CacheControlHeaderValue.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Net.Http.Headers
             if (_noCache)
             {
                 AppendValueWithSeparatorIfRequired(sb, NoCacheString);
-                if (_noCacheHeaders?.Count > 0)
+                if ((_noCacheHeaders != null) && (_noCacheHeaders.Count > 0))
                 {
                     sb.Append("=\"");
                     AppendValues(sb, _noCacheHeaders);
@@ -295,7 +295,7 @@ namespace Microsoft.Net.Http.Headers
                 (_maxStaleLimit.HasValue ? _maxStaleLimit.Value.GetHashCode() ^ 4 : 0) ^
                 (_minFresh.HasValue ? _minFresh.Value.GetHashCode() ^ 8 : 0);
 
-            if (_noCacheHeaders?.Count > 0)
+            if ((_noCacheHeaders != null) && (_noCacheHeaders.Count > 0))
             {
                 foreach (var noCacheHeader in _noCacheHeaders)
                 {
@@ -303,7 +303,7 @@ namespace Microsoft.Net.Http.Headers
                 }
             }
 
-            if (_privateHeaders?.Count > 0)
+            if ((_privateHeaders != null) && (_privateHeaders.Count > 0))
             {
                 foreach (var privateHeader in _privateHeaders)
                 {
@@ -311,7 +311,7 @@ namespace Microsoft.Net.Http.Headers
                 }
             }
 
-            if (_extensions?.Count > 0)
+            if ((_extensions != null) && (_extensions.Count > 0))
             {
                 foreach (var extension in _extensions)
                 {
@@ -503,7 +503,7 @@ namespace Microsoft.Net.Http.Headers
             var current = 1; // skip the initial '"' character.
             var maxLength = valueString.Length - 1; // -1 because we don't want to parse the final '"'.
             var separatorFound = false;
-            var originalValueCount = destination?.Count ?? 0;
+            var originalValueCount = destination == null ? 0 : destination.Count;
             while (current < maxLength)
             {
                 current = HeaderUtilities.GetNextNonEmptyOrWhitespaceIndex(valueString, current, true,

--- a/src/Microsoft.Net.Http.Headers/CacheControlHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/CacheControlHeaderValue.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Net.Http.Headers
             if (_noCache)
             {
                 AppendValueWithSeparatorIfRequired(sb, NoCacheString);
-                if ((_noCacheHeaders != null) && (_noCacheHeaders.Count > 0))
+                if (_noCacheHeaders?.Count > 0)
                 {
                     sb.Append("=\"");
                     AppendValues(sb, _noCacheHeaders);
@@ -295,7 +295,7 @@ namespace Microsoft.Net.Http.Headers
                 (_maxStaleLimit.HasValue ? _maxStaleLimit.Value.GetHashCode() ^ 4 : 0) ^
                 (_minFresh.HasValue ? _minFresh.Value.GetHashCode() ^ 8 : 0);
 
-            if ((_noCacheHeaders != null) && (_noCacheHeaders.Count > 0))
+            if (_noCacheHeaders?.Count > 0)
             {
                 foreach (var noCacheHeader in _noCacheHeaders)
                 {
@@ -303,7 +303,7 @@ namespace Microsoft.Net.Http.Headers
                 }
             }
 
-            if ((_privateHeaders != null) && (_privateHeaders.Count > 0))
+            if (_privateHeaders?.Count > 0)
             {
                 foreach (var privateHeader in _privateHeaders)
                 {
@@ -311,7 +311,7 @@ namespace Microsoft.Net.Http.Headers
                 }
             }
 
-            if ((_extensions != null) && (_extensions.Count > 0))
+            if (_extensions?.Count > 0)
             {
                 foreach (var extension in _extensions)
                 {
@@ -369,7 +369,7 @@ namespace Microsoft.Net.Http.Headers
                     return 0;
                 }
 
-                nameValueList.Add(nameValue as NameValueHeaderValue);
+                nameValueList.Add(nameValue);
             }
 
             // If we get here, we were able to successfully parse the string as list of name/value pairs. Now analyze
@@ -503,7 +503,7 @@ namespace Microsoft.Net.Http.Headers
             var current = 1; // skip the initial '"' character.
             var maxLength = valueString.Length - 1; // -1 because we don't want to parse the final '"'.
             var separatorFound = false;
-            var originalValueCount = destination == null ? 0 : destination.Count;
+            var originalValueCount = destination?.Count ?? 0;
             while (current < maxLength)
             {
                 current = HeaderUtilities.GetNextNonEmptyOrWhitespaceIndex(valueString, current, true,

--- a/src/Microsoft.Net.Http.Headers/HttpHeaderParser.cs
+++ b/src/Microsoft.Net.Http.Headers/HttpHeaderParser.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
@@ -37,11 +36,11 @@ namespace Microsoft.Net.Http.Headers
 
             // If a parser returns 'null', it means there was no value, but that's valid (e.g. "Accept: "). The caller
             // can ignore the value.
-            T result = default(T);
+            T result;
             if (!TryParseValue(value, ref index, out result))
             {
                 throw new FormatException(string.Format(CultureInfo.InvariantCulture, "Invalid value '{0}'.",
-                    value == null ? "<null>" : value.Substring(index)));
+                    value?.Substring(index) ?? "<null>"));
             }
             return result;
         }
@@ -114,7 +113,7 @@ namespace Microsoft.Net.Http.Headers
                     else
                     {
                         throw new FormatException(string.Format(CultureInfo.InvariantCulture, "Invalid values '{0}'.",
-                            values == null ? "<null>" : value.Substring(index)));
+                            value.Substring(index)));
                     }
                 }
             }

--- a/src/Microsoft.Net.Http.Headers/StringWithQualityHeaderValueComparer.cs
+++ b/src/Microsoft.Net.Http.Headers/StringWithQualityHeaderValueComparer.cs
@@ -64,13 +64,13 @@ namespace Microsoft.Net.Http.Headers
                 return 1;
             }
 
-            if (!String.Equals(stringWithQuality1.Value, stringWithQuality2.Value, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(stringWithQuality1.Value, stringWithQuality2.Value, StringComparison.OrdinalIgnoreCase))
             {
-                if (String.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
+                if (string.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
                 {
                     return -1;
                 }
-                else if (String.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
+                else if (string.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
                 {
                     return 1;
                 }

--- a/test/Microsoft.Net.Http.Headers.Tests/CookieHeaderValueTest.cs
+++ b/test/Microsoft.Net.Http.Headers.Tests/CookieHeaderValueTest.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Net.Http.Headers
         public void CookieHeaderValue_Value()
         {
             var cookie = new CookieHeaderValue("name");
-            Assert.Equal(String.Empty, cookie.Value);
+            Assert.Equal(string.Empty, cookie.Value);
 
             cookie.Value = "value1";
             Assert.Equal("value1", cookie.Value);

--- a/test/Microsoft.Net.Http.Headers.Tests/SetCookieHeaderValueTest.cs
+++ b/test/Microsoft.Net.Http.Headers.Tests/SetCookieHeaderValueTest.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Net.Http.Headers
         public void SetCookieHeaderValue_Value()
         {
             var cookie = new SetCookieHeaderValue("name");
-            Assert.Equal(String.Empty, cookie.Value);
+            Assert.Equal(string.Empty, cookie.Value);
 
             cookie.Value = "value1";
             Assert.Equal("value1", cookie.Value);


### PR DESCRIPTION
The main intent is cleanup using C# 6 operators and normalization of type aliases. While there are no intended functional changes here, it does eliminate a few tight race conditions as a bonus (not a real-win since this isn't thread-safe all over, simply noting).