### PR TITLE
Revert use of explicit converters that prevent APIs from returning null.

### DIFF
--- a/src/Microsoft.AspNet.Http.Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/HeaderDictionaryExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Http
         /// <returns>the associated values from the collection separated into individual values, or StringValues.Empty if the key is not present.</returns>
         public static string[] GetCommaSeparatedValues(this IHeaderDictionary headers, string key)
         {
-            return ParsingHelpers.GetHeaderSplit(headers, key).ToArray();
+            return ParsingHelpers.GetHeaderSplit(headers, key);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Http.Extensions/HeaderDictionaryTypeExtensions.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/HeaderDictionaryTypeExtensions.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNet.Http
             if (KnownParsers.TryGetValue(typeof(T), out temp))
             {
                 var func = (Func<string, T>)temp;
-                return func(headers[name].ToString());
+                return func(headers[name]);
             }
 
             var value = headers[name];
@@ -202,7 +202,7 @@ namespace Microsoft.AspNet.Http
             if (KnownListParsers.TryGetValue(typeof(T), out temp))
             {
                 var func = (Func<IList<string>, IList<T>>)temp;
-                return func(headers[name].ToArray());
+                return func(headers[name]);
             }
 
             var values = headers[name];

--- a/src/Microsoft.AspNet.Http.Extensions/Internal/ParsingHelpers.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/Internal/ParsingHelpers.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Http.Internal
                 return;
             }
 
-            string existing = GetHeader(headers, key).ToString();
+            string existing = GetHeader(headers, key);
             if (existing == null)
             {
                 SetHeaderJoined(headers, key, values);

--- a/src/Microsoft.AspNet.Http.Extensions/RequestHeaders.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/RequestHeaders.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNet.Http.Headers
         {
             get
             {
-                return HostString.FromUriComponent(Headers[HeaderNames.Host].ToString());
+                return HostString.FromUriComponent(Headers[HeaderNames.Host]);
             }
             set
             {

--- a/src/Microsoft.AspNet.Http.Extensions/ResponseHeaders.cs
+++ b/src/Microsoft.AspNet.Http.Extensions/ResponseHeaders.cs
@@ -134,7 +134,7 @@ namespace Microsoft.AspNet.Http.Headers
             get
             {
                 Uri uri;
-                if (Uri.TryCreate(Headers[HeaderNames.Location].ToString(), UriKind.RelativeOrAbsolute, out uri))
+                if (Uri.TryCreate(Headers[HeaderNames.Location], UriKind.RelativeOrAbsolute, out uri))
                 {
                     return uri;
                 }

--- a/src/Microsoft.AspNet.Http/DefaultHttpRequest.cs
+++ b/src/Microsoft.AspNet.Http/DefaultHttpRequest.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNet.Http.Internal
 
         public override HostString Host
         {
-            get { return HostString.FromUriComponent(Headers["Host"].ToString()); }
+            get { return HostString.FromUriComponent(Headers["Host"]); }
             set { Headers["Host"] = value.ToUriComponent(); }
         }
 

--- a/src/Microsoft.AspNet.Http/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNet.Http/DefaultHttpResponse.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNet.Http.Internal
         {
             get
             {
-                return Headers[HeaderNames.ContentType].ToString();
+                return Headers[HeaderNames.ContentType];
             }
             set
             {

--- a/src/Microsoft.AspNet.Http/DefaultWebSocketManager.cs
+++ b/src/Microsoft.AspNet.Http/DefaultWebSocketManager.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNet.Http.Internal
         {
             get
             {
-                return ParsingHelpers.GetHeaderSplit(HttpRequestFeature.Headers, HeaderNames.WebSocketSubProtocols).ToArray();
+                return ParsingHelpers.GetHeaderSplit(HttpRequestFeature.Headers, HeaderNames.WebSocketSubProtocols);
             }
         }
 

--- a/src/Microsoft.AspNet.Http/Features/FormFile.cs
+++ b/src/Microsoft.AspNet.Http/Features/FormFile.cs
@@ -21,13 +21,13 @@ namespace Microsoft.AspNet.Http.Features.Internal
 
         public string ContentDisposition
         {
-            get { return Headers["Content-Disposition"].ToString(); }
+            get { return Headers["Content-Disposition"]; }
             set { Headers["Content-Disposition"] = value; }
         }
 
         public string ContentType
         {
-            get { return Headers["Content-Type"].ToString(); }
+            get { return Headers["Content-Type"]; }
             set { Headers["Content-Type"] = value; }
         }
 

--- a/src/Microsoft.AspNet.Http/RequestCookieCollection.cs
+++ b/src/Microsoft.AspNet.Http/RequestCookieCollection.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Http.Internal
 
                 if (Store == null)
                 {
-                    return string.Empty;
+                    return null;
                 }
 
                 string value;
@@ -56,7 +56,7 @@ namespace Microsoft.AspNet.Http.Internal
                 {
                     return value;
                 }
-                return string.Empty;
+                return null;
             }
         }
         
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Http.Internal
         {
             if (Store == null)
             {
-                value = string.Empty;
+                value = null;
                 return false;
             }
             return Store.TryGetValue(key, out value);

--- a/src/Microsoft.AspNet.WebUtilities/MultipartReader.cs
+++ b/src/Microsoft.AspNet.WebUtilities/MultipartReader.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNet.WebUtilities
                     throw new InvalidOperationException("Total header size limit exceeded: " + TotalHeaderSizeLimit.ToString());
                 }
                 int splitIndex = line.IndexOf(':');
-                Debug.Assert(splitIndex > 0, $"Invalid header line: {line.ToString()}");
+                Debug.Assert(splitIndex > 0, $"Invalid header line: {line}");
                 if (splitIndex >= 0)
                 {
                     var name = line.Substring(0, splitIndex);

--- a/src/Microsoft.AspNet.WebUtilities/MultipartSection.cs
+++ b/src/Microsoft.AspNet.WebUtilities/MultipartSection.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.WebUtilities
                 StringValues values;
                 if (Headers.TryGetValue("Content-Type", out values))
                 {
-                    return values.ToString();
+                    return values;
                 }
                 return null;
             }
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.WebUtilities
                 StringValues values;
                 if (Headers.TryGetValue("Content-Disposition", out values))
                 {
-                    return values.ToString();
+                    return values;
                 }
                 return null;
             }

--- a/test/Microsoft.AspNet.Http.Tests/DefaultHttpRequestTests.cs
+++ b/test/Microsoft.AspNet.Http.Tests/DefaultHttpRequestTests.cs
@@ -169,6 +169,8 @@ namespace Microsoft.AspNet.Http.Internal
             Assert.Equal(0, cookieHeaders.Count);
             var cookies0 = request.Cookies;
             Assert.Equal(0, cookies0.Count);
+            Assert.Null(cookies0["key0"]);
+            Assert.False(cookies0.ContainsKey("key0"));
 
             var newCookies = new[] { "name0=value0", "name1=value1" };
             request.Headers["Cookie"] = newCookies;

--- a/test/Microsoft.AspNet.Http.Tests/DefaultHttpResponseTests.cs
+++ b/test/Microsoft.AspNet.Http.Tests/DefaultHttpResponseTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.AspNet.Http.Features;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNet.Http.Internal
+{
+    public class DefaultHttpResponseTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(9001)]
+        [InlineData(65535)]
+        public void GetContentLength_ReturnsParsedHeader(long value)
+        {
+            // Arrange
+            var response = GetResponseWithContentLength(value.ToString(CultureInfo.InvariantCulture));
+
+            // Act and Assert
+            Assert.Equal(value, response.ContentLength);
+        }
+
+        [Fact]
+        public void GetContentLength_ReturnsNullIfHeaderDoesNotExist()
+        {
+            // Arrange
+            var response = GetResponseWithContentLength(contentLength: null);
+
+            // Act and Assert
+            Assert.Null(response.ContentLength);
+        }
+
+        [Theory]
+        [InlineData("cant-parse-this")]
+        [InlineData("-1000")]
+        [InlineData("1000.00")]
+        [InlineData("100/5")]
+        public void GetContentLength_ReturnsNullIfHeaderCannotBeParsed(string contentLength)
+        {
+            // Arrange
+            var response = GetResponseWithContentLength(contentLength);
+
+            // Act and Assert
+            Assert.Null(response.ContentLength);
+        }
+
+        [Fact]
+        public void GetContentType_ReturnsNullIfHeaderDoesNotExist()
+        {
+            // Arrange
+            var response = GetResponseWithContentType(contentType: null);
+
+            // Act and Assert
+            Assert.Null(response.ContentType);
+        }
+
+        private static HttpResponse CreateResponse(IHeaderDictionary headers)
+        {
+            var context = new DefaultHttpContext();
+            context.Features.Get<IHttpResponseFeature>().Headers = headers;
+            return context.Response;
+        }
+
+        private static HttpResponse GetResponseWithContentLength(string contentLength = null)
+        {
+            return GetResponseWithHeader("Content-Length", contentLength);
+        }
+
+        private static HttpResponse GetResponseWithContentType(string contentType = null)
+        {
+            return GetResponseWithHeader("Content-Type", contentType);
+        }
+
+        private static HttpResponse GetResponseWithHeader(string headerName, string headerValue)
+        {
+            var headers = new HeaderDictionary();
+            if (headerValue != null)
+            {
+                headers.Add(headerName, headerValue);
+            }
+
+            return CreateResponse(headers);
+        }
+    }
+}


### PR DESCRIPTION
Reverting the use of explicit type converters (ToString and ToArray) that were preventing some APIs from returning null. The implicit converters can return null.

See https://github.com/aspnet/Common/blob/dev/src/Microsoft.Extensions.Primitives/StringValues.cs#L85
https://github.com/aspnet/Common/blob/dev/src/Microsoft.Extensions.Primitives/StringValues.cs#L104

@rynowak 
/cc @benaadams 