### PR TITLE
Add Name and FileName to IFormFile

### DIFF
--- a/src/Microsoft.AspNet.Http.Abstractions/IFormFile.cs
+++ b/src/Microsoft.AspNet.Http.Abstractions/IFormFile.cs
@@ -18,6 +18,10 @@ namespace Microsoft.AspNet.Http
 
         long Length { get; }
 
+        string Name { get; }
+
+        string FileName { get; }
+
         Stream OpenReadStream();
     }
 }

--- a/src/Microsoft.AspNet.Http/Features/FormFeature.cs
+++ b/src/Microsoft.AspNet.Http/Features/FormFeature.cs
@@ -149,7 +149,10 @@ namespace Microsoft.AspNet.Http.Features.Internal
                             // Find the end
                             await section.Body.DrainAsync(cancellationToken);
 
-                            var file = new FormFile(_request.Body, section.BaseStreamOffset.Value, section.Body.Length)
+                            var name = HeaderUtilities.RemoveQuotes(contentDisposition.Name) ?? string.Empty;
+                            var fileName = HeaderUtilities.RemoveQuotes(contentDisposition.FileName) ?? string.Empty;
+
+                            var file = new FormFile(_request.Body, section.BaseStreamOffset.Value, section.Body.Length, name, fileName)
                             {
                                 Headers = new HeaderDictionary(section.Headers),
                             };

--- a/src/Microsoft.AspNet.Http/Features/FormFile.cs
+++ b/src/Microsoft.AspNet.Http/Features/FormFile.cs
@@ -8,15 +8,16 @@ namespace Microsoft.AspNet.Http.Features.Internal
 {
     public class FormFile : IFormFile
     {
-        private Stream _baseStream;
-        private long _baseStreamOffset;
-        private long _length;
+        private readonly Stream _baseStream;
+        private readonly long _baseStreamOffset;
 
-        public FormFile(Stream baseStream, long baseStreamOffset, long length)
+        public FormFile(Stream baseStream, long baseStreamOffset, long length, string name, string fileName)
         {
             _baseStream = baseStream;
             _baseStreamOffset = baseStreamOffset;
-            _length = length;
+            Length = length;
+            Name = name;
+            FileName = fileName;
         }
 
         public string ContentDisposition
@@ -33,14 +34,15 @@ namespace Microsoft.AspNet.Http.Features.Internal
 
         public IHeaderDictionary Headers { get; set; }
 
-        public long Length
-        {
-            get { return _length; }
-        }
+        public long Length { get; }
+
+        public string Name { get; }
+
+        public string FileName { get; }
 
         public Stream OpenReadStream()
         {
-            return new ReferenceReadStream(_baseStream, _baseStreamOffset, _length);
+            return new ReferenceReadStream(_baseStream, _baseStreamOffset, Length);
         }
     }
 }

--- a/src/Microsoft.AspNet.Http/FormFileCollection.cs
+++ b/src/Microsoft.AspNet.Http/FormFileCollection.cs
@@ -1,34 +1,41 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
-using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Http.Internal
 {
     public class FormFileCollection : List<IFormFile>, IFormFileCollection
     {
-        public IFormFile this[string name]
-        {
-            get { return GetFile(name); }
-        }
+        public IFormFile this[string name] => GetFile(name);
 
         public IFormFile GetFile(string name)
         {
-            return Find(file => string.Equals(name, GetName(file.ContentDisposition)));
+            foreach (var file in this)
+            {
+                if (string.Equals(name, file.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return file;
+                }
+            }
+
+            return null;
         }
 
         public IReadOnlyList<IFormFile> GetFiles(string name)
         {
-            return FindAll(file => string.Equals(name, GetName(file.ContentDisposition)));
-        }
+            var files = new List<IFormFile>();
 
-        private static string GetName(string contentDisposition)
-        {
-            // Content-Disposition: form-data; name="myfile1"; filename="Misc 002.jpg"
-            ContentDispositionHeaderValue cd;
-            ContentDispositionHeaderValue.TryParse(contentDisposition, out cd);
-            return HeaderUtilities.RemoveQuotes(cd?.Name);
+            foreach (var file in this)
+            {
+                if (string.Equals(name, file.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    files.Add(file);
+                }
+            }
+
+            return files;
         }
     }
 }

--- a/test/Microsoft.AspNet.Http.Tests/FormFeatureTests.cs
+++ b/test/Microsoft.AspNet.Http.Tests/FormFeatureTests.cs
@@ -215,6 +215,8 @@ namespace Microsoft.AspNet.Http.Features.Internal
             Assert.Equal(1, formCollection.Files.Count);
 
             var file = formCollection.Files["myfile1"];
+            Assert.Equal("myfile1", file.Name);
+            Assert.Equal("temp.html", file.FileName);
             Assert.Equal("text/html", file.ContentType);
             Assert.Equal(@"form-data; name=""myfile1""; filename=""temp.html""", file.ContentDisposition);
             var body = file.OpenReadStream();


### PR DESCRIPTION
Fixes #499. These names should probably be cached somewhere. Anyone opposed to exposing a `Name` property on `IFormFile` backed by a `Lazy<string>`?