### PR TITLE
Feature/#446 content disposition

### DIFF
--- a/src/Microsoft.Net.Http.Headers/ContentDispositionHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/ContentDispositionHeaderValue.cs
@@ -64,13 +64,13 @@ namespace Microsoft.Net.Http.Headers
 
         public string Name
         {
-            get { return GetName(NameString); }
+            get { return Unquote(GetName(NameString)); }
             set { SetName(NameString, value); }
         }
 
         public string FileName
         {
-            get { return GetName(FileNameString); }
+            get { return Unquote(GetName(FileNameString)); }
             set { SetName(FileNameString, value); }
         }
 
@@ -460,6 +460,16 @@ namespace Microsoft.Net.Http.Headers
 
             return value.Length > 1 && value.StartsWith("\"", StringComparison.Ordinal)
                 && value.EndsWith("\"", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Unquotes string if it is not null. Does nothing if the string is null.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private string Unquote(string value)
+        {
+            return value == null ? value : value.Trim('"');
         }
 
         // tspecials are required to be in a quoted string.  Only non-ascii needs to be encoded.

--- a/test/Microsoft.Net.Http.Headers.Tests/ContentDispositionHeaderValueTest.cs
+++ b/test/Microsoft.Net.Http.Headers.Tests/ContentDispositionHeaderValueTest.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(1, contentDisposition.Parameters.Count);
             Assert.Equal("FILENAME", contentDisposition.Parameters.First().Name);
             Assert.Equal("\"=?utf-99?Q?R=mlsZcODTmFtZS5iYXQ=?=\"", contentDisposition.Parameters.First().Value);
-            Assert.Equal("\"=?utf-99?Q?R=mlsZcODTmFtZS5iYXQ=?=\"", contentDisposition.FileName);
+            Assert.Equal("=?utf-99?Q?R=mlsZcODTmFtZS5iYXQ=?=", contentDisposition.FileName);
 
             contentDisposition.FileName = "new_name";
             Assert.Equal("new_name", contentDisposition.FileName);

--- a/test/Microsoft.Net.Http.Headers.Tests/ContentDispositionHeaderValueTest.cs
+++ b/test/Microsoft.Net.Http.Headers.Tests/ContentDispositionHeaderValueTest.cs
@@ -418,6 +418,34 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
+        public void Parse_FileNameWithoutQuotes()
+        {
+            //  arrange
+            string contentDisposition = $"form-data; name=\"avatar\"; filename=\"my-face.png\"";
+            string expected = "my-face.png";
+
+            //  act
+            var parsed = ContentDispositionHeaderValue.Parse(contentDisposition);
+
+            //  assert
+            Assert.Equal(expected, parsed.FileName);
+        }
+
+        [Fact]
+        public void Parse_NameWithoutQuotes()
+        {
+            //  arrange
+            string contentDisposition = $"form-data; name=\"avatar\"; filename=\"my-face.png\"";
+            string expected = "avatar";
+
+            //  act
+            var parsed = ContentDispositionHeaderValue.Parse(contentDisposition);
+
+            //  assert
+            Assert.Equal(expected, parsed.Name);
+        }
+
+        [Fact]
         public void Parse_SetOfInvalidValueStrings_Throws()
         {
             CheckInvalidParse("");


### PR DESCRIPTION
This resolves issue #446. 

It turned out that `IFormFile` now has `FileName` property, so there's no need to use `ContentDispositionHeaderValue.Parse()` to parse `IFormFile.ContentDisposition` in MVC controller action.

But nevertheless `ContentDispositionHeaderValue.Parse()` is still publicly available and can be used to parse `IFormFile.ContentDisposition`. That method returns an instance of `ContentDispositionHeaderValue`, that has `FileName` property.

Here's an example of `IFormFile.ContentDisposition` value: 
```
form-data; name="avatar"; filename="my-face.png"
``` 
This is the case when user posted a file named "my-face.png" from html page with form with `enctype="multipart/form-data"` and input with `name="avatar"`.

So when we parse this ContentDisposition with `ContentDispositionHeaderValue.Parse()`, we get an instance of `ContentDispositionHeaderValue` with FileName containing **quoted** "my-face.png" and Name containing **quoted** "avatar". This is not convenient, so this MR unquotes those values.