### PR TITLE
Use System.Buffers

### DIFF
--- a/src/Microsoft.AspNetCore.Http/BufferingHelper.cs
+++ b/src/Microsoft.AspNetCore.Http/BufferingHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Http.Internal
 {
     public static class BufferingHelper
     {
-        internal const int DefaultBufferThreshold = 1024 * 30;
+        internal const int DefaultBufferThreshold = 32768;
 
         private readonly static Func<string> _getTempDirectory = () => TempDirectory;
 

--- a/src/Microsoft.AspNetCore.Http/project.json
+++ b/src/Microsoft.AspNetCore.Http/project.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.0-*",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0-*",
-    "Microsoft.Net.Http.Headers": "1.0.0-*"
+    "Microsoft.Net.Http.Headers": "1.0.0-*",
+    "System.Buffers": "4.0.0-*"
   },
   "frameworks": {
     "net451": {},

--- a/src/Microsoft.AspNetCore.WebUtilities/BufferedReadStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/BufferedReadStream.cs
@@ -17,11 +17,17 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         private readonly Stream _inner;
         private readonly byte[] _buffer;
+        private readonly ArrayPool<byte> _bytePool;
         private int _bufferOffset = 0;
         private int _bufferCount = 0;
         private bool _disposed;
 
         public BufferedReadStream(Stream inner, int bufferSize)
+            : this(inner, bufferSize, ArrayPool<byte>.Shared)
+        {
+        }
+
+        public BufferedReadStream(Stream inner, int bufferSize, ArrayPool<byte> bytePool)
         {
             if (inner == null)
             {
@@ -29,7 +35,8 @@ namespace Microsoft.AspNetCore.WebUtilities
             }
 
             _inner = inner;
-            _buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            _bytePool = bytePool;
+            _buffer = bytePool.Rent(bufferSize);
         }
 
         public ArraySegment<byte> BufferedData
@@ -132,7 +139,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             if (!_disposed)
             {
                 _disposed = true;
-                ArrayPool<byte>.Shared.Return(_buffer);
+                _bytePool.Return(_buffer);
 
                 if (disposing)
                 {

--- a/src/Microsoft.AspNetCore.WebUtilities/FileBufferingReadStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FileBufferingReadStream.cs
@@ -73,6 +73,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         // TODO: allow for an optional buffer size limit to prevent filling hard disks. 1gb?
         public FileBufferingReadStream(Stream inner, int memoryThreshold, string tempFileDirectory)
+            : this (inner, memoryThreshold, tempFileDirectory, ArrayPool<byte>.Shared)
         {
         }
 

--- a/src/Microsoft.AspNetCore.WebUtilities/FileBufferingReadStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FileBufferingReadStream.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         private Stream _buffer;
         private byte[] _rentedBuffer;
+        private int _readIntoBuffer = 0;
         private bool _inMemory = true;
         private bool _completelyBuffered;
 
@@ -73,13 +74,13 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         // TODO: allow for an optional buffer size limit to prevent filling hard disks. 1gb?
         public FileBufferingReadStream(Stream inner, int memoryThreshold, string tempFileDirectory)
-            : this (inner, memoryThreshold, tempFileDirectory, ArrayPool<byte>.Shared)
+            : this(inner, memoryThreshold, tempFileDirectory, ArrayPool<byte>.Shared)
         {
         }
 
         public FileBufferingReadStream(
-            Stream inner, 
-            int memoryThreshold, 
+            Stream inner,
+            int memoryThreshold,
             string tempFileDirectory,
             ArrayPool<byte> bytePool)
         {
@@ -178,26 +179,27 @@ namespace Microsoft.AspNetCore.WebUtilities
         public override int Read(byte[] buffer, int offset, int count)
         {
             ThrowIfDisposed();
-            if (_buffer.Position < _buffer.Length || _completelyBuffered)
+            if (_buffer.Position < _readIntoBuffer || _completelyBuffered)
             {
                 // Just read from the buffer
-                return _buffer.Read(buffer, offset, (int)Math.Min(count, _buffer.Length - _buffer.Position));
+                return _buffer.Read(buffer, offset, (int)Math.Min(count, _readIntoBuffer - _buffer.Position));
             }
 
             int read = _inner.Read(buffer, offset, count);
 
-            if (_inMemory && _buffer.Length + read > _memoryThreshold)
+            if (_inMemory && _readIntoBuffer + read > _memoryThreshold)
             {
                 _inMemory = false;
                 checked
                 {
-                    int length = (int)_buffer.Length;
+                    int length = _readIntoBuffer;
                     _buffer = CreateTempFile();
                     _buffer.Write(_rentedBuffer, 0, length);
                     _bytePool.Return(_rentedBuffer);
                     _rentedBuffer = null;
                 }
             }
+            _readIntoBuffer += read;
 
             if (read > 0)
             {
@@ -253,26 +255,27 @@ namespace Microsoft.AspNetCore.WebUtilities
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            if (_buffer.Position < _buffer.Length || _completelyBuffered)
+            if (_buffer.Position < _readIntoBuffer || _completelyBuffered)
             {
                 // Just read from the buffer
-                return await _buffer.ReadAsync(buffer, offset, (int)Math.Min(count, _buffer.Length - _buffer.Position), cancellationToken);
+                return await _buffer.ReadAsync(buffer, offset, (int)Math.Min(count, _readIntoBuffer - _buffer.Position), cancellationToken);
             }
 
             int read = await _inner.ReadAsync(buffer, offset, count, cancellationToken);
 
-            if (_inMemory && _buffer.Length + read > _memoryThreshold)
+            if (_inMemory && _readIntoBuffer + read > _memoryThreshold)
             {
                 _inMemory = false;
                 checked
                 {
-                    int length = (int)_buffer.Length;
+                    int length = _readIntoBuffer;
                     _buffer = CreateTempFile();
                     await _buffer.WriteAsync(_rentedBuffer, 0, length, cancellationToken);
                     _bytePool.Return(_rentedBuffer);
                     _rentedBuffer = null;
                 }
             }
+            _readIntoBuffer += read;
 
             if (read > 0)
             {

--- a/src/Microsoft.AspNetCore.WebUtilities/FormReader.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FormReader.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNetCore.WebUtilities
     {
         private readonly TextReader _reader;
         private readonly char[] _buffer;
+        private readonly ArrayPool<byte> _bytePool;
         private readonly ArrayPool<char> _charPool;
         private readonly StringBuilder _builder = new StringBuilder();
         private int _bufferOffset;
@@ -26,11 +27,11 @@ namespace Microsoft.AspNetCore.WebUtilities
         private bool _disposed;
 
         public FormReader(string data)
-            : this(data, ArrayPool<char>.Shared)
+            : this(data, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
         }
 
-        public FormReader(string data, ArrayPool<char> charPool)
+        public FormReader(string data, ArrayPool<byte> bytePool, ArrayPool<char> charPool)
         {
             if (data == null)
             {
@@ -39,15 +40,16 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             _buffer = charPool.Rent(1024);
             _charPool = charPool;
+            _bytePool = bytePool;
             _reader = new StringReader(data);
         }
 
         public FormReader(Stream stream, Encoding encoding)
-            : this(stream, encoding, ArrayPool<char>.Shared)
+            : this(stream, encoding, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
         }
 
-        public FormReader(Stream stream, Encoding encoding, ArrayPool<char> charPool)
+        public FormReader(Stream stream, Encoding encoding, ArrayPool<byte> bytePool, ArrayPool<char> charPool)
         {
             if (stream == null)
             {
@@ -61,6 +63,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             _buffer = charPool.Rent(1024);
             _charPool = charPool;
+            _bytePool = bytePool;
             _reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: 1024 * 2, leaveOpen: true);
         }
 
@@ -157,10 +160,13 @@ namespace Microsoft.AspNetCore.WebUtilities
         // '+' un-escapes to ' ', %HH un-escapes as ASCII (or utf-8?)
         private string BuildWord()
         {
-            _builder.Replace('+', ' ');
-            var result = _builder.ToString();
+            if (_builder.Length == 0)
+            {
+                return string.Empty;
+            }
+            var result = UrlDecode(_builder, _bytePool, _charPool);
             _builder.Clear();
-            return Uri.UnescapeDataString(result); // TODO: Replace this, it's not completely accurate.
+            return result;
         }
 
         private void Buffer()
@@ -235,6 +241,164 @@ namespace Microsoft.AspNetCore.WebUtilities
             {
                 _disposed = true;
                 _charPool.Return(_buffer);
+            }
+        }
+
+        // Algorithm from https://github.com/dotnet/corefx/blob/ac67ffac987d0c27236c4a6cf1255c2bcbc7fe7d/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs#L378
+        // but accepting StringBuilder
+        private string UrlDecode(StringBuilder value, ArrayPool<byte> bytePool, ArrayPool<char> charPool)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            var count = value.Length;
+            UrlDecoder helper = new UrlDecoder(count, Encoding.UTF8, bytePool, charPool);
+
+            // go through the string's chars collapsing %XX and
+            // appending each char as char, with exception of %XX constructs
+            // that are appended as bytes
+
+            for (var pos = 0; pos < count; pos++)
+            {
+                var ch = value[pos];
+
+                if (ch == '+')
+                {
+                    ch = ' ';
+                }
+                else if (ch == '%' && pos < count - 2)
+                {
+                    var h1 = HexToInt(value[pos + 1]);
+                    var h2 = HexToInt(value[pos + 2]);
+
+                    if (h1 >= 0 && h2 >= 0)
+                    {     // valid 2 hex chars
+                        var b = (byte)((h1 << 4) | h2);
+                        pos += 2;
+
+                        // don't add as char
+                        helper.AddByte(b);
+                        continue;
+                    }
+                }
+
+                if ((ch & 0xFF80) == 0)
+                {
+                    helper.AddByte((byte)ch); // 7 bit have to go as bytes because of Unicode
+                }
+                else
+                {
+                    helper.AddChar(ch);
+                }
+            }
+
+            var decodedString = helper.GetString();
+            helper.Dispose();
+
+            return decodedString;
+        }
+
+        // from https://github.com/dotnet/corefx/blob/ac67ffac987d0c27236c4a6cf1255c2bcbc7fe7d/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs#L529
+        // as private static there
+        private static int HexToInt(char h)
+        {
+            return (h >= '0' && h <= '9') ? h - '0' :
+            (h >= 'a' && h <= 'f') ? h - 'a' + 10 :
+            (h >= 'A' && h <= 'F') ? h - 'A' + 10 :
+            -1;
+        }
+
+        // from https://github.com/dotnet/corefx/blob/ac67ffac987d0c27236c4a6cf1255c2bcbc7fe7d/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs#L610
+        // but lower allocation struct
+        private struct UrlDecoder
+        {
+            private int _bufferSize;
+
+            // Accumulate characters in a special array
+            private int _numChars;
+            private char[] _charBuffer;
+
+            // Accumulate bytes for decoding into characters in a special array
+            private int _numBytes;
+            private byte[] _byteBuffer;
+
+            // Encoding to convert chars to bytes
+            private Encoding _encoding;
+
+            private ArrayPool<byte> _bytePool;
+            private ArrayPool<char> _charPool;
+
+            public UrlDecoder(int bufferSize, Encoding encoding, ArrayPool<byte> bytePool, ArrayPool<char> charPool)
+            {
+                _bufferSize = bufferSize;
+                _encoding = encoding;
+                _numChars = 0;
+                _numBytes = 0;
+
+                _bytePool = bytePool;
+                _charPool = charPool;
+
+                _byteBuffer = null;
+                _charBuffer = charPool.Rent(bufferSize);
+                // byte buffer created on demand
+            }
+
+            private void FlushBytes()
+            {
+                if (_numBytes > 0)
+                {
+                    _numChars += _encoding.GetChars(_byteBuffer, 0, _numBytes, _charBuffer, _numChars);
+                    _numBytes = 0;
+                }
+            }
+
+            public void AddChar(char ch)
+            {
+                if (_numBytes > 0)
+                {
+                    FlushBytes();
+                }
+
+                _charBuffer[_numChars++] = ch;
+            }
+
+            public void AddByte(byte b)
+            {
+                if (_byteBuffer == null)
+                {
+                    _byteBuffer = _bytePool.Rent(_bufferSize);
+                }
+
+                _byteBuffer[_numBytes++] = b;
+            }
+
+            public string GetString()
+            {
+                if (_numBytes > 0)
+                {
+                    FlushBytes();
+                }
+
+                if (_numChars > 0)
+                {
+                    return new string(_charBuffer, 0, _numChars);
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+
+            public void Dispose()
+            {
+                _charPool.Return(_charBuffer);
+
+                if (_byteBuffer != null)
+                {
+                    _bytePool.Return(_byteBuffer);
+                }
             }
         }
     }

--- a/src/Microsoft.AspNetCore.WebUtilities/FormReader.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FormReader.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 throw new ArgumentNullException(nameof(data));
             }
 
-            _buffer = charPool.Rent(1024);
+            _buffer = charPool.Rent(8192);
             _charPool = charPool;
             _bytePool = bytePool;
             _reader = new StringReader(data);
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            _buffer = charPool.Rent(1024);
+            _buffer = charPool.Rent(8192);
             _charPool = charPool;
             _bytePool = bytePool;
             _reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: 1024 * 2, leaveOpen: true);
@@ -160,13 +160,10 @@ namespace Microsoft.AspNetCore.WebUtilities
         // '+' un-escapes to ' ', %HH un-escapes as ASCII (or utf-8?)
         private string BuildWord()
         {
-            if (_builder.Length == 0)
-            {
-                return string.Empty;
-            }
-            var result = UrlDecode(_builder, _bytePool, _charPool);
+            _builder.Replace('+', ' ');
+            var result = _builder.ToString();
             _builder.Clear();
-            return result;
+            return Uri.UnescapeDataString(result); // TODO: Replace this, it's not completely accurate.
         }
 
         private void Buffer()
@@ -241,164 +238,6 @@ namespace Microsoft.AspNetCore.WebUtilities
             {
                 _disposed = true;
                 _charPool.Return(_buffer);
-            }
-        }
-
-        // Algorithm from https://github.com/dotnet/corefx/blob/ac67ffac987d0c27236c4a6cf1255c2bcbc7fe7d/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs#L378
-        // but accepting StringBuilder
-        private string UrlDecode(StringBuilder value, ArrayPool<byte> bytePool, ArrayPool<char> charPool)
-        {
-            if (value == null)
-            {
-                return null;
-            }
-
-            var count = value.Length;
-            UrlDecoder helper = new UrlDecoder(count, Encoding.UTF8, bytePool, charPool);
-
-            // go through the string's chars collapsing %XX and
-            // appending each char as char, with exception of %XX constructs
-            // that are appended as bytes
-
-            for (var pos = 0; pos < count; pos++)
-            {
-                var ch = value[pos];
-
-                if (ch == '+')
-                {
-                    ch = ' ';
-                }
-                else if (ch == '%' && pos < count - 2)
-                {
-                    var h1 = HexToInt(value[pos + 1]);
-                    var h2 = HexToInt(value[pos + 2]);
-
-                    if (h1 >= 0 && h2 >= 0)
-                    {     // valid 2 hex chars
-                        var b = (byte)((h1 << 4) | h2);
-                        pos += 2;
-
-                        // don't add as char
-                        helper.AddByte(b);
-                        continue;
-                    }
-                }
-
-                if ((ch & 0xFF80) == 0)
-                {
-                    helper.AddByte((byte)ch); // 7 bit have to go as bytes because of Unicode
-                }
-                else
-                {
-                    helper.AddChar(ch);
-                }
-            }
-
-            var decodedString = helper.GetString();
-            helper.Dispose();
-
-            return decodedString;
-        }
-
-        // from https://github.com/dotnet/corefx/blob/ac67ffac987d0c27236c4a6cf1255c2bcbc7fe7d/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs#L529
-        // as private static there
-        private static int HexToInt(char h)
-        {
-            return (h >= '0' && h <= '9') ? h - '0' :
-            (h >= 'a' && h <= 'f') ? h - 'a' + 10 :
-            (h >= 'A' && h <= 'F') ? h - 'A' + 10 :
-            -1;
-        }
-
-        // from https://github.com/dotnet/corefx/blob/ac67ffac987d0c27236c4a6cf1255c2bcbc7fe7d/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs#L610
-        // but lower allocation struct
-        private struct UrlDecoder
-        {
-            private int _bufferSize;
-
-            // Accumulate characters in a special array
-            private int _numChars;
-            private char[] _charBuffer;
-
-            // Accumulate bytes for decoding into characters in a special array
-            private int _numBytes;
-            private byte[] _byteBuffer;
-
-            // Encoding to convert chars to bytes
-            private Encoding _encoding;
-
-            private ArrayPool<byte> _bytePool;
-            private ArrayPool<char> _charPool;
-
-            public UrlDecoder(int bufferSize, Encoding encoding, ArrayPool<byte> bytePool, ArrayPool<char> charPool)
-            {
-                _bufferSize = bufferSize;
-                _encoding = encoding;
-                _numChars = 0;
-                _numBytes = 0;
-
-                _bytePool = bytePool;
-                _charPool = charPool;
-
-                _byteBuffer = null;
-                _charBuffer = charPool.Rent(bufferSize);
-                // byte buffer created on demand
-            }
-
-            private void FlushBytes()
-            {
-                if (_numBytes > 0)
-                {
-                    _numChars += _encoding.GetChars(_byteBuffer, 0, _numBytes, _charBuffer, _numChars);
-                    _numBytes = 0;
-                }
-            }
-
-            public void AddChar(char ch)
-            {
-                if (_numBytes > 0)
-                {
-                    FlushBytes();
-                }
-
-                _charBuffer[_numChars++] = ch;
-            }
-
-            public void AddByte(byte b)
-            {
-                if (_byteBuffer == null)
-                {
-                    _byteBuffer = _bytePool.Rent(_bufferSize);
-                }
-
-                _byteBuffer[_numBytes++] = b;
-            }
-
-            public string GetString()
-            {
-                if (_numBytes > 0)
-                {
-                    FlushBytes();
-                }
-
-                if (_numChars > 0)
-                {
-                    return new string(_charBuffer, 0, _numChars);
-                }
-                else
-                {
-                    return string.Empty;
-                }
-            }
-
-            public void Dispose()
-            {
-                _charPool.Return(_charBuffer);
-
-                if (_byteBuffer != null)
-                {
-                    _bytePool.Return(_byteBuffer);
-                }
             }
         }
     }

--- a/src/Microsoft.AspNetCore.WebUtilities/HttpRequestStreamReader.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpRequestStreamReader.cs
@@ -34,40 +34,13 @@ namespace Microsoft.AspNetCore.WebUtilities
         private bool _isBlocked;
 
         public HttpRequestStreamReader(Stream stream, Encoding encoding)
-            : this(stream, encoding, DefaultBufferSize)
+            : this(stream, encoding, DefaultBufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
         }
 
         public HttpRequestStreamReader(Stream stream, Encoding encoding, int bufferSize)
+            : this(stream, encoding, bufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            if (!stream.CanRead)
-            {
-                throw new ArgumentException(Resources.HttpRequestStreamReader_StreamNotReadable, nameof(stream));
-            }
-
-            if (encoding == null)
-            {
-                throw new ArgumentNullException(nameof(encoding));
-            }
-
-            _stream = stream;
-            _encoding = encoding;
-            _decoder = encoding.GetDecoder();
-
-            if (bufferSize < MinBufferSize)
-            {
-                bufferSize = MinBufferSize;
-            }
-
-            _byteBufferSize = bufferSize;
-            _byteBuffer = new byte[bufferSize];
-            var maxCharsPerBuffer = encoding.GetMaxCharCount(bufferSize);
-            _charBuffer = new char[maxCharsPerBuffer];
         }
 
         public HttpRequestStreamReader(

--- a/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
@@ -34,39 +34,13 @@ namespace Microsoft.AspNetCore.WebUtilities
         private int _charBufferCount;
 
         public HttpResponseStreamWriter(Stream stream, Encoding encoding)
-            : this(stream, encoding, DefaultBufferSize)
+            : this(stream, encoding, DefaultBufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
         }
 
         public HttpResponseStreamWriter(Stream stream, Encoding encoding, int bufferSize)
+            : this(stream, encoding, bufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            if (!stream.CanWrite)
-            {
-                throw new ArgumentException(Resources.HttpResponseStreamWriter_StreamNotWritable, nameof(stream));
-            }
-
-            if (encoding == null)
-            {
-                throw new ArgumentNullException(nameof(encoding));
-            }
-
-            _stream = stream;
-            Encoding = encoding;
-            _charBufferSize = bufferSize;
-
-            if (bufferSize < MinBufferSize)
-            {
-                bufferSize = MinBufferSize;
-            }
-
-            _encoder = encoding.GetEncoder();
-            _byteBuffer = new byte[encoding.GetMaxByteCount(bufferSize)];
-            _charBuffer = new char[bufferSize];
         }
 
         public HttpResponseStreamWriter(

--- a/src/Microsoft.AspNetCore.WebUtilities/MultipartReaderStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/MultipartReaderStream.cs
@@ -242,6 +242,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 // or -- for the final boundary.
                 var boundary = _bytePool.Rent(_boundaryBytes.Length);
                 read = _innerStream.Read(boundary, 0, _boundaryBytes.Length);
+                _bytePool.Return(boundary);
                 Debug.Assert(read == _boundaryBytes.Length); // It should have all been buffered
                 var remainder = _innerStream.ReadLine(lengthLimit: 100); // Whitespace may exceed the buffer.
                 remainder = remainder.Trim();
@@ -249,7 +250,6 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     FinalBoundaryFound = true;
                 }
-                _bytePool.Return(boundary);
                 Debug.Assert(FinalBoundaryFound || string.Equals(string.Empty, remainder, StringComparison.Ordinal), "Un-expected data found on the boundary line: " + remainder);
                 _finished = true;
                 return 0;
@@ -294,6 +294,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 // or -- for the final boundary.
                 var boundary = _bytePool.Rent(_boundaryBytes.Length);
                 read = _innerStream.Read(boundary, 0, _boundaryBytes.Length);
+                _bytePool.Return(boundary);
                 Debug.Assert(read == _boundaryBytes.Length); // It should have all been buffered
                 var remainder = await _innerStream.ReadLineAsync(lengthLimit: 100, cancellationToken: cancellationToken); // Whitespace may exceed the buffer.
                 remainder = remainder.Trim();
@@ -301,7 +302,6 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     FinalBoundaryFound = true;
                 }
-                _bytePool.Return(boundary);
                 Debug.Assert(FinalBoundaryFound || string.Equals(string.Empty, remainder, StringComparison.Ordinal), "Un-expected data found on the boundary line: " + remainder);
 
                 _finished = true;

--- a/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.WebUtilities
     {
         public static Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
         {
-            return stream.DrainAsync(cancellationToken, ArrayPool<byte>.Shared);
+            return stream.DrainAsync(ArrayPool<byte>.Shared, cancellationToken);
         }
-        public static async Task DrainAsync(this Stream stream, CancellationToken cancellationToken, ArrayPool<byte> bytePool)
+        public static async Task DrainAsync(this Stream stream, ArrayPool<byte> bytePool, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var buffer = bytePool.Rent(1024);

--- a/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
@@ -12,14 +12,20 @@ namespace Microsoft.AspNetCore.WebUtilities
     {
         public static async Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
         {
-            var buffer = ArrayPool<byte>.Shared.Rent(1024);
             cancellationToken.ThrowIfCancellationRequested();
-            while (await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken) > 0)
+            var buffer = ArrayPool<byte>.Shared.Rent(1024);
+            try
             {
-                // Not all streams support cancellation directly.
-                cancellationToken.ThrowIfCancellationRequested();
+                while (await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken) > 0)
+                {
+                    // Not all streams support cancellation directly.
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
             }
-            ArrayPool<byte>.Shared.Return(buffer);
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
@@ -10,10 +10,14 @@ namespace Microsoft.AspNetCore.WebUtilities
 {
     public static class StreamHelperExtensions
     {
-        public static async Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
+        public static Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
+        {
+            return stream.DrainAsync(cancellationToken, ArrayPool<byte>.Shared);
+        }
+        public static async Task DrainAsync(this Stream stream, CancellationToken cancellationToken, ArrayPool<byte> bytePool)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var buffer = ArrayPool<byte>.Shared.Rent(1024);
+            var buffer = bytePool.Rent(1024);
             try
             {
                 while (await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken) > 0)
@@ -24,7 +28,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(buffer);
+                bytePool.Return(buffer);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,13 +12,14 @@ namespace Microsoft.AspNetCore.WebUtilities
     {
         public static async Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
         {
-            byte[] buffer = new byte[1024];
+            var buffer = ArrayPool<byte>.Shared.Rent(1024);
             cancellationToken.ThrowIfCancellationRequested();
             while (await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken) > 0)
             {
                 // Not all streams support cancellation directly.
                 cancellationToken.ThrowIfCancellationRequested();
             }
+            ArrayPool<byte>.Shared.Return(buffer);
         }
     }
 }

--- a/src/Microsoft.Net.Http.Headers/ContentDispositionHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/ContentDispositionHeaderValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
@@ -578,12 +579,13 @@ namespace Microsoft.Net.Http.Headers
             }
 
             var decoded = new StringBuilder();
+            byte[] unescapedBytes = null;
             try
             {
                 var encoding = Encoding.GetEncoding(parts[0]);
 
                 var dataString = parts[2];
-                var unescapedBytes = new byte[dataString.Length];
+                unescapedBytes = ArrayPool<byte>.Shared.Rent(dataString.Length);
                 var unescapedBytesCount = 0;
                 for (var index = 0; index < dataString.Length; index++)
                 {
@@ -613,9 +615,17 @@ namespace Microsoft.Net.Http.Headers
             }
             catch (ArgumentException)
             {
+                if (unescapedBytes != null)
+                {
+                    ArrayPool<byte>.Shared.Return(unescapedBytes);
+                }
                 return false; // Unknown encoding or bad characters
             }
 
+            if (unescapedBytes != null)
+            {
+                ArrayPool<byte>.Shared.Return(unescapedBytes);
+            }
             output = decoded.ToString();
             return true;
         }

--- a/src/Microsoft.Net.Http.Headers/project.json
+++ b/src/Microsoft.Net.Http.Headers/project.json
@@ -9,9 +9,15 @@
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk"
   },
-  "dependencies": {},
+  "dependencies": {
+    "System.Buffers": "4.0.0-*"
+  },
   "frameworks": {
-    "net451": {},
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    },
     "dotnet5.4": {
       "dependencies": {
         "System.Collections": "4.0.11-*",


### PR DESCRIPTION
Resolves #545

Added System.Buffer

 - [X] OwinWebSocketAdapter.CloseAsync
 - [X] Microsoft.AspNetCore.WebUtilities.BufferedReadStream.ctor
 - [X] Microsoft.AspNetCore.WebUtilities.FormReader.ctor (variable initialized)
 - [X] Microsoft.AspNetCore.WebUtilities.HttpRequestStreamReader.ctor
 - [X] Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.ctor
 - [X] Microsoft.AspNetCore.WebUtilities.MultipartReaderStream.Read
 - [X] Microsoft.AspNetCore.WebUtilities.MultipartReaderStream.ReadAsync
 - [X] Microsoft.AspNetCore.WebUtilities.StreamHelperExtensions.DrainAsync
 - [X] Microsoft.AspNetCore.WebUtilities.WebEncoders.Base64UrlDecode
 - [X] Microsoft.AspNetCore.WebUtilities.WebEncoders.Base64UrlEncode
 - [X] Microsoft.Net.Http.Headers.ContentDispositionHeaderValue.TryDecode5987

Extra 

- [X] Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream

Now also resolves #548 

...except when content is buffered to disk; which needs this issue resolving in corefx https://github.com/dotnet/corefx/issues/5598 
Due to `FileStream`'s internal buffer is not being exposed/settable.