### PR TITLE
Make forgiving vs strict cookie parsers.

### DIFF
--- a/src/Microsoft.Net.Http.Headers/EntityTagHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/EntityTagHeaderValue.cs
@@ -129,9 +129,19 @@ namespace Microsoft.Net.Http.Headers
             return MultipleValueParser.ParseValues(inputs);
         }
 
+        public static IList<EntityTagHeaderValue> ParseStrictList(IList<string> inputs)
+        {
+            return MultipleValueParser.ParseStrictValues(inputs);
+        }
+
         public static bool TryParseList(IList<string> inputs, out IList<EntityTagHeaderValue> parsedValues)
         {
             return MultipleValueParser.TryParseValues(inputs, out parsedValues);
+        }
+
+        public static bool TryParseStrictList(IList<string> inputs, out IList<EntityTagHeaderValue> parsedValues)
+        {
+            return MultipleValueParser.TryParseStrictValues(inputs, out parsedValues);
         }
 
         internal static int GetEntityTagLength(string input, int startIndex, out EntityTagHeaderValue parsedValue)

--- a/src/Microsoft.Net.Http.Headers/MediaTypeHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/MediaTypeHeaderValue.cs
@@ -391,9 +391,19 @@ namespace Microsoft.Net.Http.Headers
             return MultipleValueParser.ParseValues(inputs);
         }
 
+        public static IList<MediaTypeHeaderValue> ParseStrictList(IList<string> inputs)
+        {
+            return MultipleValueParser.ParseStrictValues(inputs);
+        }
+
         public static bool TryParseList(IList<string> inputs, out IList<MediaTypeHeaderValue> parsedValues)
         {
             return MultipleValueParser.TryParseValues(inputs, out parsedValues);
+        }
+
+        public static bool TryParseStrictList(IList<string> inputs, out IList<MediaTypeHeaderValue> parsedValues)
+        {
+            return MultipleValueParser.TryParseStrictValues(inputs, out parsedValues);
         }
 
         private static int GetMediaTypeLength(string input, int startIndex, out MediaTypeHeaderValue parsedValue)

--- a/src/Microsoft.Net.Http.Headers/NameValueHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/NameValueHeaderValue.cs
@@ -158,9 +158,19 @@ namespace Microsoft.Net.Http.Headers
             return MultipleValueParser.ParseValues(input);
         }
 
+        public static IList<NameValueHeaderValue> ParseStrictList(IList<string> input)
+        {
+            return MultipleValueParser.ParseStrictValues(input);
+        }
+
         public static bool TryParseList(IList<string> input, out IList<NameValueHeaderValue> parsedValues)
         {
             return MultipleValueParser.TryParseValues(input, out parsedValues);
+        }
+
+        public static bool TryParseStrictList(IList<string> input, out IList<NameValueHeaderValue> parsedValues)
+        {
+            return MultipleValueParser.TryParseStrictValues(input, out parsedValues);
         }
 
         public override string ToString()

--- a/src/Microsoft.Net.Http.Headers/SetCookieHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/SetCookieHeaderValue.cs
@@ -156,9 +156,19 @@ namespace Microsoft.Net.Http.Headers
             return MultipleValueParser.ParseValues(inputs);
         }
 
+        public static IList<SetCookieHeaderValue> ParseStrictList(IList<string> inputs)
+        {
+            return MultipleValueParser.ParseStrictValues(inputs);
+        }
+
         public static bool TryParseList(IList<string> inputs, out IList<SetCookieHeaderValue> parsedValues)
         {
             return MultipleValueParser.TryParseValues(inputs, out parsedValues);
+        }
+
+        public static bool TryParseStrictList(IList<string> inputs, out IList<SetCookieHeaderValue> parsedValues)
+        {
+            return MultipleValueParser.TryParseStrictValues(inputs, out parsedValues);
         }
 
         // name=value; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; httponly
@@ -195,12 +205,9 @@ namespace Microsoft.Net.Http.Headers
                 return 0;
             }
 
-            string value;
             // value or "quoted value"
-            itemLength = CookieHeaderValue.GetCookieValueLength(input, offset, out value);
             // The value may be empty
-            result._value = input.Substring(offset, itemLength);
-            offset += itemLength;
+            result._value = CookieHeaderValue.GetCookieValue(input, ref offset);
 
             // *(';' SP cookie-av)
             while (offset < input.Length)

--- a/src/Microsoft.Net.Http.Headers/StringWithQualityHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/StringWithQualityHeaderValue.cs
@@ -119,9 +119,19 @@ namespace Microsoft.Net.Http.Headers
             return MultipleValueParser.ParseValues(input);
         }
 
+        public static IList<StringWithQualityHeaderValue> ParseStrictList(IList<string> input)
+        {
+            return MultipleValueParser.ParseStrictValues(input);
+        }
+
         public static bool TryParseList(IList<string> input, out IList<StringWithQualityHeaderValue> parsedValues)
         {
             return MultipleValueParser.TryParseValues(input, out parsedValues);
+        }
+
+        public static bool TryParseStrictList(IList<string> input, out IList<StringWithQualityHeaderValue> parsedValues)
+        {
+            return MultipleValueParser.TryParseStrictValues(input, out parsedValues);
         }
 
         private static int GetStringWithQualityLength(string input, int startIndex, out StringWithQualityHeaderValue parsedValue)

--- a/test/Microsoft.Net.Http.Headers.Tests/EntityTagHeaderValueTest.cs
+++ b/test/Microsoft.Net.Http.Headers.Tests/EntityTagHeaderValueTest.cs
@@ -213,6 +213,39 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
+        public void ParseStrictList_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            var inputs = new[]
+            {
+                "",
+                "\"tag\"",
+                "",
+                " \"tag\" ",
+                "\r\n \"tag\"\r\n ",
+                "\"tag会\"",
+                "\"tag\",\"tag\"",
+                "\"tag\", \"tag\"",
+                "W/\"tag\"",
+            };
+            IList<EntityTagHeaderValue> results = EntityTagHeaderValue.ParseStrictList(inputs);
+
+            var expectedResults = new[]
+            {
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag会\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\"", true),
+            }.ToList();
+
+            Assert.Equal(expectedResults, results);
+        }
+
+        [Fact]
         public void TryParseList_SetOfValidValueStrings_ParsedCorrectly()
         {
             var inputs = new[]
@@ -246,7 +279,40 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void ParseList_WithSomeInvlaidValues_Throws()
+        public void TryParseStrictList_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            var inputs = new[]
+            {
+                "",
+                "\"tag\"",
+                "",
+                " \"tag\" ",
+                "\r\n \"tag\"\r\n ",
+                "\"tag会\"",
+                "\"tag\",\"tag\"",
+                "\"tag\", \"tag\"",
+                "W/\"tag\"",
+            };
+            IList<EntityTagHeaderValue> results;
+            Assert.True(EntityTagHeaderValue.TryParseStrictList(inputs, out results));
+            var expectedResults = new[]
+            {
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag会\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\"", true),
+            }.ToList();
+
+            Assert.Equal(expectedResults, results);
+        }
+
+        [Fact]
+        public void ParseList_WithSomeInvlaidValues_ExcludesInvalidValues()
         {
             var inputs = new[]
             {
@@ -260,11 +326,41 @@ namespace Microsoft.Net.Http.Headers
                 "\"tag\", \"tag\"",
                 "W/\"tag\"",
             };
-            Assert.Throws<FormatException>(() => EntityTagHeaderValue.ParseList(inputs));
+            var results = EntityTagHeaderValue.ParseList(inputs);
+            var expectedResults = new[]
+            {
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag会\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\"", true),
+            }.ToList();
+
+            Assert.Equal(expectedResults, results);
         }
 
         [Fact]
-        public void TryParseList_WithSomeInvlaidValues_ReturnsFalse()
+        public void ParseStrictList_WithSomeInvlaidValues_Throws()
+        {
+            var inputs = new[]
+            {
+                "",
+                "\"tag\", tag, \"tag\"",
+                "tag, \"tag\"",
+                "",
+                " \"tag ",
+                "\r\n tag\"\r\n ",
+                "\"tag会\"",
+                "\"tag\", \"tag\"",
+                "W/\"tag\"",
+            };
+            Assert.Throws<FormatException>(() => EntityTagHeaderValue.ParseStrictList(inputs));
+        }
+
+        [Fact]
+        public void TryParseList_WithSomeInvlaidValues_ExcludesInvalidValues()
         {
             var inputs = new[]
             {
@@ -279,7 +375,38 @@ namespace Microsoft.Net.Http.Headers
                 "W/\"tag\"",
             };
             IList<EntityTagHeaderValue> results;
-            Assert.False(EntityTagHeaderValue.TryParseList(inputs, out results));
+            Assert.True(EntityTagHeaderValue.TryParseList(inputs, out results));
+            var expectedResults = new[]
+            {
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag会\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\""),
+                new EntityTagHeaderValue("\"tag\"", true),
+            }.ToList();
+
+            Assert.Equal(expectedResults, results);
+        }
+
+        [Fact]
+        public void TryParseStrictList_WithSomeInvlaidValues_ReturnsFalse()
+        {
+            var inputs = new[]
+            {
+                "",
+                "\"tag\", tag, \"tag\"",
+                "tag, \"tag\"",
+                "",
+                " \"tag ",
+                "\r\n tag\"\r\n ",
+                "\"tag会\"",
+                "\"tag\", \"tag\"",
+                "W/\"tag\"",
+            };
+            IList<EntityTagHeaderValue> results;
+            Assert.False(EntityTagHeaderValue.TryParseStrictList(inputs, out results));
         }
 
         private void CheckValidParse(string input, EntityTagHeaderValue expectedResult)


### PR DESCRIPTION
#515 @rynowak @lodejard @riegelj @muratg 
Provide strict and forgiving versions of the list parsers. The forgiving version attempts to read past and discard invalid values.

This is preliminary only, the other headers will also need to be updated if we like the design changes. Some of their tests are currently broken by the changes.