### PR TITLE
Use System.Buffers + ValueTask in FormReading

### DIFF
--- a/src/Microsoft.AspNetCore.Http/BufferingHelper.cs
+++ b/src/Microsoft.AspNetCore.Http/BufferingHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Http.Internal
 {
     public static class BufferingHelper
     {
-        internal const int DefaultBufferThreshold = 1024 * 30;
+        internal const int DefaultBufferThreshold = 32768;
 
         private readonly static Func<string> _getTempDirectory = () => TempDirectory;
 

--- a/src/Microsoft.AspNetCore.Http/project.json
+++ b/src/Microsoft.AspNetCore.Http/project.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.0-*",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0-*",
-    "Microsoft.Net.Http.Headers": "1.0.0-*"
+    "Microsoft.Net.Http.Headers": "1.0.0-*",
+    "System.Buffers": "4.0.0-*"
   },
   "frameworks": {
     "net451": {},

--- a/src/Microsoft.AspNetCore.Owin/WebSockets/OwinWebSocketAdapter.cs
+++ b/src/Microsoft.AspNetCore.Owin/WebSockets/OwinWebSocketAdapter.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Owin
 
     public class OwinWebSocketAdapter : WebSocket
     {
+        private const int _rentedBufferSize = 1024;
         private IDictionary<string, object> _websocketContext;
         private WebSocketSendAsync _sendAsync;
         private WebSocketReceiveAsync _receiveAsync;
@@ -127,7 +128,7 @@ namespace Microsoft.AspNetCore.Owin
                 await CloseOutputAsync(closeStatus, statusDescription, cancellationToken);
             }
 
-            var buffer = ArrayPool<byte>.Shared.Rent(1024);
+            var buffer = ArrayPool<byte>.Shared.Rent(_rentedBufferSize);
             try
             {
                 while (State == WebSocketState.CloseSent)

--- a/src/Microsoft.AspNetCore.WebUtilities/FileBufferingReadStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FileBufferingReadStream.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.WebUtilities
     /// </summary>
     public class FileBufferingReadStream : Stream
     {
+        private const int _maxRentedBufferSize = 1024 * 1024; // 1MB
         private readonly Stream _inner;
         private readonly ArrayPool<byte> _bytePool;
         private readonly int _memoryThreshold;
@@ -25,7 +26,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         private Stream _buffer;
         private byte[] _rentedBuffer;
-        private int _readIntoBuffer = 0;
+        private int _readIntoBuffer;
         private bool _inMemory = true;
         private bool _completelyBuffered;
 
@@ -57,7 +58,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             }
 
             _bytePool = bytePool;
-            if (memoryThreshold < 1024 * 1024)
+            if (memoryThreshold < _maxRentedBufferSize)
             {
                 _rentedBuffer = bytePool.Rent(memoryThreshold);
                 _buffer = new MemoryStream(_rentedBuffer);
@@ -95,7 +96,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             }
 
             _bytePool = bytePool;
-            if (memoryThreshold < 1024 * 1024)
+            if (memoryThreshold < _maxRentedBufferSize)
             {
                 _rentedBuffer = bytePool.Rent(memoryThreshold);
                 _buffer = new MemoryStream(_rentedBuffer);

--- a/src/Microsoft.AspNetCore.WebUtilities/FormReader.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FormReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -14,25 +15,39 @@ namespace Microsoft.AspNetCore.WebUtilities
     /// <summary>
     /// Used to read an 'application/x-www-form-urlencoded' form.
     /// </summary>
-    public class FormReader
+    public class FormReader : IDisposable
     {
         private readonly TextReader _reader;
-        private readonly char[] _buffer = new char[1024];
+        private readonly char[] _buffer;
+        private readonly ArrayPool<char> _charPool;
         private readonly StringBuilder _builder = new StringBuilder();
         private int _bufferOffset;
         private int _bufferCount;
+        private bool _disposed;
 
         public FormReader(string data)
+            : this(data, ArrayPool<char>.Shared)
+        {
+        }
+
+        public FormReader(string data, ArrayPool<char> charPool)
         {
             if (data == null)
             {
                 throw new ArgumentNullException(nameof(data));
             }
 
+            _buffer = charPool.Rent(1024);
+            _charPool = charPool;
             _reader = new StringReader(data);
         }
 
         public FormReader(Stream stream, Encoding encoding)
+            : this(stream, encoding, ArrayPool<char>.Shared)
+        {
+        }
+
+        public FormReader(Stream stream, Encoding encoding, ArrayPool<char> charPool)
         {
             if (stream == null)
             {
@@ -44,6 +59,8 @@ namespace Microsoft.AspNetCore.WebUtilities
                 throw new ArgumentNullException(nameof(encoding));
             }
 
+            _buffer = charPool.Rent(1024);
+            _charPool = charPool;
             _reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: 1024 * 2, leaveOpen: true);
         }
 
@@ -167,17 +184,18 @@ namespace Microsoft.AspNetCore.WebUtilities
         /// <returns>The collection containing the parsed HTTP form body.</returns>
         public static Dictionary<string, StringValues> ReadForm(string text)
         {
-            var reader = new FormReader(text);
-
-            var accumulator = new KeyValueAccumulator();
-            var pair = reader.ReadNextPair();
-            while (pair.HasValue)
+            using (var reader = new FormReader(text))
             {
-                accumulator.Append(pair.Value.Key, pair.Value.Value);
-                pair = reader.ReadNextPair();
-            }
+                var accumulator = new KeyValueAccumulator();
+                var pair = reader.ReadNextPair();
+                while (pair.HasValue)
+                {
+                    accumulator.Append(pair.Value.Key, pair.Value.Value);
+                    pair = reader.ReadNextPair();
+                }
 
-            return accumulator.GetResults();
+                return accumulator.GetResults();
+            }
         }
 
         /// <summary>
@@ -200,17 +218,27 @@ namespace Microsoft.AspNetCore.WebUtilities
         /// <returns>The collection containing the parsed HTTP form body.</returns>
         public static async Task<Dictionary<string, StringValues>> ReadFormAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken = new CancellationToken())
         {
-            var reader = new FormReader(stream, encoding);
-
-            var accumulator = new KeyValueAccumulator();
-            var pair = await reader.ReadNextPairAsync(cancellationToken);
-            while (pair.HasValue)
+            using (var reader = new FormReader(stream, encoding))
             {
-                accumulator.Append(pair.Value.Key, pair.Value.Value);
-                pair = await reader.ReadNextPairAsync(cancellationToken);
-            }
+                var accumulator = new KeyValueAccumulator();
+                var pair = await reader.ReadNextPairAsync(cancellationToken);
+                while (pair.HasValue)
+                {
+                    accumulator.Append(pair.Value.Key, pair.Value.Value);
+                    pair = await reader.ReadNextPairAsync(cancellationToken);
+                }
 
-            return accumulator.GetResults();
+                return accumulator.GetResults();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                _charPool.Return(_buffer);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebUtilities/FormReader.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FormReader.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.WebUtilities
     /// </summary>
     public class FormReader : IDisposable
     {
+        private const int _rentedCharPoolLength = 8192;
         private readonly TextReader _reader;
         private readonly char[] _buffer;
         private readonly ArrayPool<byte> _bytePool;
@@ -38,7 +39,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 throw new ArgumentNullException(nameof(data));
             }
 
-            _buffer = charPool.Rent(8192);
+            _buffer = charPool.Rent(_rentedCharPoolLength);
             _charPool = charPool;
             _bytePool = bytePool;
             _reader = new StringReader(data);
@@ -61,7 +62,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            _buffer = charPool.Rent(8192);
+            _buffer = charPool.Rent(_rentedCharPoolLength);
             _charPool = charPool;
             _bytePool = bytePool;
             _reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: 1024 * 2, leaveOpen: true);

--- a/src/Microsoft.AspNetCore.WebUtilities/HttpRequestStreamReader.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpRequestStreamReader.cs
@@ -34,40 +34,13 @@ namespace Microsoft.AspNetCore.WebUtilities
         private bool _isBlocked;
 
         public HttpRequestStreamReader(Stream stream, Encoding encoding)
-            : this(stream, encoding, DefaultBufferSize)
+            : this(stream, encoding, DefaultBufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
         }
 
         public HttpRequestStreamReader(Stream stream, Encoding encoding, int bufferSize)
+            : this(stream, encoding, bufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            if (!stream.CanRead)
-            {
-                throw new ArgumentException(Resources.HttpRequestStreamReader_StreamNotReadable, nameof(stream));
-            }
-
-            if (encoding == null)
-            {
-                throw new ArgumentNullException(nameof(encoding));
-            }
-
-            _stream = stream;
-            _encoding = encoding;
-            _decoder = encoding.GetDecoder();
-
-            if (bufferSize < MinBufferSize)
-            {
-                bufferSize = MinBufferSize;
-            }
-
-            _byteBufferSize = bufferSize;
-            _byteBuffer = new byte[bufferSize];
-            var maxCharsPerBuffer = encoding.GetMaxCharCount(bufferSize);
-            _charBuffer = new char[maxCharsPerBuffer];
         }
 
         public HttpRequestStreamReader(

--- a/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
@@ -34,39 +34,13 @@ namespace Microsoft.AspNetCore.WebUtilities
         private int _charBufferCount;
 
         public HttpResponseStreamWriter(Stream stream, Encoding encoding)
-            : this(stream, encoding, DefaultBufferSize)
+            : this(stream, encoding, DefaultBufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
         }
 
         public HttpResponseStreamWriter(Stream stream, Encoding encoding, int bufferSize)
+            : this(stream, encoding, bufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            if (!stream.CanWrite)
-            {
-                throw new ArgumentException(Resources.HttpResponseStreamWriter_StreamNotWritable, nameof(stream));
-            }
-
-            if (encoding == null)
-            {
-                throw new ArgumentNullException(nameof(encoding));
-            }
-
-            _stream = stream;
-            Encoding = encoding;
-            _charBufferSize = bufferSize;
-
-            if (bufferSize < MinBufferSize)
-            {
-                bufferSize = MinBufferSize;
-            }
-
-            _encoder = encoding.GetEncoder();
-            _byteBuffer = new byte[encoding.GetMaxByteCount(bufferSize)];
-            _charBuffer = new char[bufferSize];
         }
 
         public HttpResponseStreamWriter(

--- a/src/Microsoft.AspNetCore.WebUtilities/MultipartReaderStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/MultipartReaderStream.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -13,6 +14,8 @@ namespace Microsoft.AspNetCore.WebUtilities
     {
         private readonly MultipartBoundary _boundary;
         private readonly BufferedReadStream _innerStream;
+        private readonly ArrayPool<byte> _bytePool;
+
         private readonly long _innerOffset;
         private long _position;
         private long _observedLength;
@@ -24,6 +27,17 @@ namespace Microsoft.AspNetCore.WebUtilities
         /// <param name="stream">The <see cref="BufferedReadStream"/>.</param>
         /// <param name="boundary">The boundary pattern to use.</param>
         public MultipartReaderStream(BufferedReadStream stream, MultipartBoundary boundary)
+            : this(stream, boundary, ArrayPool<byte>.Shared)
+        {
+        }
+
+        /// <summary>
+        /// Creates a stream that reads until it reaches the given boundary pattern.
+        /// </summary>
+        /// <param name="stream">The <see cref="BufferedReadStream"/>.</param>
+        /// <param name="boundary">The boundary pattern to use.</param>
+        /// <param name="bytePool">The ArrayPool pool to use for temporary byte arrays.</param>
+        public MultipartReaderStream(BufferedReadStream stream, MultipartBoundary boundary, ArrayPool<byte> bytePool)
         {
             if (stream == null)
             {
@@ -35,6 +49,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 throw new ArgumentNullException(nameof(boundary));
             }
 
+            _bytePool = bytePool;
             _innerStream = stream;
             _innerOffset = _innerStream.CanSeek ? _innerStream.Position : 0;
             _boundary = boundary;
@@ -212,22 +227,25 @@ namespace Microsoft.AspNetCore.WebUtilities
                     read = _innerStream.Read(buffer, offset, Math.Min(count, matchOffset - bufferedData.Offset));
                     return UpdatePosition(read);
                 }
-                Debug.Assert(matchCount == _boundary.BoundaryBytes.Length);
+
+                var length = _boundary.BoundaryBytes.Length;
+                Debug.Assert(matchCount == length);
 
                 // "The boundary may be followed by zero or more characters of
                 // linear whitespace. It is then terminated by either another CRLF"
                 // or -- for the final boundary.
-                byte[] boundary = new byte[_boundary.BoundaryBytes.Length];
-                read = _innerStream.Read(boundary, 0, boundary.Length);
-                Debug.Assert(read == boundary.Length); // It should have all been buffered
+                var boundary = _bytePool.Rent(length);
+                read = _innerStream.Read(boundary, 0, length);
+                Debug.Assert(read == length); // It should have all been buffered
+
                 var remainder = _innerStream.ReadLine(lengthLimit: 100); // Whitespace may exceed the buffer.
                 remainder = remainder.Trim();
                 if (string.Equals("--", remainder, StringComparison.Ordinal))
                 {
                     FinalBoundaryFound = true;
                 }
+                _bytePool.Return(boundary);
                 Debug.Assert(FinalBoundaryFound || string.Equals(string.Empty, remainder, StringComparison.Ordinal), "Un-expected data found on the boundary line: " + remainder);
-
                 _finished = true;
                 return 0;
             }
@@ -264,20 +282,24 @@ namespace Microsoft.AspNetCore.WebUtilities
                     read = _innerStream.Read(buffer, offset, Math.Min(count, matchOffset - bufferedData.Offset));
                     return UpdatePosition(read);
                 }
-                Debug.Assert(matchCount == _boundary.BoundaryBytes.Length);
+
+                var length = _boundary.BoundaryBytes.Length;
+                Debug.Assert(matchCount == length);
 
                 // "The boundary may be followed by zero or more characters of
                 // linear whitespace. It is then terminated by either another CRLF"
                 // or -- for the final boundary.
-                byte[] boundary = new byte[_boundary.BoundaryBytes.Length];
-                read = _innerStream.Read(boundary, 0, boundary.Length);
-                Debug.Assert(read == boundary.Length); // It should have all been buffered
+                var boundary = _bytePool.Rent(length);
+                read = _innerStream.Read(boundary, 0, length);
+                Debug.Assert(read == length); // It should have all been buffered
+
                 var remainder = await _innerStream.ReadLineAsync(lengthLimit: 100, cancellationToken: cancellationToken); // Whitespace may exceed the buffer.
                 remainder = remainder.Trim();
                 if (string.Equals("--", remainder, StringComparison.Ordinal))
                 {
                     FinalBoundaryFound = true;
                 }
+                _bytePool.Return(boundary);
                 Debug.Assert(FinalBoundaryFound || string.Equals(string.Empty, remainder, StringComparison.Ordinal), "Un-expected data found on the boundary line: " + remainder);
 
                 _finished = true;

--- a/src/Microsoft.AspNetCore.WebUtilities/MultipartReaderStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/MultipartReaderStream.cs
@@ -236,6 +236,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 // or -- for the final boundary.
                 var boundary = _bytePool.Rent(length);
                 read = _innerStream.Read(boundary, 0, length);
+                _bytePool.Return(boundary);
                 Debug.Assert(read == length); // It should have all been buffered
 
                 var remainder = _innerStream.ReadLine(lengthLimit: 100); // Whitespace may exceed the buffer.
@@ -244,7 +245,6 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     FinalBoundaryFound = true;
                 }
-                _bytePool.Return(boundary);
                 Debug.Assert(FinalBoundaryFound || string.Equals(string.Empty, remainder, StringComparison.Ordinal), "Un-expected data found on the boundary line: " + remainder);
                 _finished = true;
                 return 0;
@@ -291,15 +291,15 @@ namespace Microsoft.AspNetCore.WebUtilities
                 // or -- for the final boundary.
                 var boundary = _bytePool.Rent(length);
                 read = _innerStream.Read(boundary, 0, length);
+                _bytePool.Return(boundary);
                 Debug.Assert(read == length); // It should have all been buffered
-
+				
                 var remainder = await _innerStream.ReadLineAsync(lengthLimit: 100, cancellationToken: cancellationToken); // Whitespace may exceed the buffer.
                 remainder = remainder.Trim();
                 if (string.Equals("--", remainder, StringComparison.Ordinal))
                 {
                     FinalBoundaryFound = true;
                 }
-                _bytePool.Return(boundary);
                 Debug.Assert(FinalBoundaryFound || string.Equals(string.Empty, remainder, StringComparison.Ordinal), "Un-expected data found on the boundary line: " + remainder);
 
                 _finished = true;

--- a/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.WebUtilities
     {
         public static Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
         {
-            return stream.DrainAsync(cancellationToken, ArrayPool<byte>.Shared);
+            return stream.DrainAsync(ArrayPool<byte>.Shared, cancellationToken);
         }
-        public static async Task DrainAsync(this Stream stream, CancellationToken cancellationToken, ArrayPool<byte> bytePool)
+        public static async Task DrainAsync(this Stream stream, ArrayPool<byte> bytePool, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var buffer = bytePool.Rent(1024);

--- a/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
@@ -10,14 +10,17 @@ namespace Microsoft.AspNetCore.WebUtilities
 {
     public static class StreamHelperExtensions
     {
+        private const int _maxReadBufferSize = 1024;
+
         public static Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
         {
             return stream.DrainAsync(ArrayPool<byte>.Shared, cancellationToken);
         }
+
         public static async Task DrainAsync(this Stream stream, ArrayPool<byte> bytePool, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var buffer = bytePool.Rent(1024);
+            var buffer = bytePool.Rent(_maxReadBufferSize);
             try
             {
                 while (await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken) > 0)

--- a/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,14 +10,25 @@ namespace Microsoft.AspNetCore.WebUtilities
 {
     public static class StreamHelperExtensions
     {
-        public static async Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
+        public static Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
         {
-            byte[] buffer = new byte[1024];
+            return stream.DrainAsync(cancellationToken, ArrayPool<byte>.Shared);
+        }
+        public static async Task DrainAsync(this Stream stream, CancellationToken cancellationToken, ArrayPool<byte> bytePool)
+        {
             cancellationToken.ThrowIfCancellationRequested();
-            while (await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken) > 0)
+            var buffer = bytePool.Rent(1024);
+            try
             {
-                // Not all streams support cancellation directly.
-                cancellationToken.ThrowIfCancellationRequested();
+                while (await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken) > 0)
+                {
+                    // Not all streams support cancellation directly.
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+            finally
+            {
+                bytePool.Return(buffer);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.WebUtilities/project.json
+++ b/src/Microsoft.AspNetCore.WebUtilities/project.json
@@ -16,12 +16,14 @@
   "dependencies": {
     "Microsoft.Extensions.Primitives": "1.0.0-*",
     "System.Buffers": "4.0.0-*",
-    "System.Text.Encodings.Web": "4.0.0-*"
+    "System.Text.Encodings.Web": "4.0.0-*",
+    "System.Threading.Tasks.Extensions": "4.0.0-*"
   },
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Runtime": { "type": "build" }
+        "System.Runtime": { "type": "build" },
+        "System.Threading.Tasks": "4.0.0.0"
       }
     },
     "netstandard1.3": {

--- a/src/Microsoft.AspNetCore.WebUtilities/project.json
+++ b/src/Microsoft.AspNetCore.WebUtilities/project.json
@@ -23,7 +23,7 @@
     "net451": {
       "frameworkAssemblies": {
         "System.Runtime": { "type": "build" },
-        "System.Threading.Tasks": "4.0.0.0"
+        "System.Threading.Tasks": { "type": "build" }
       }
     },
     "netstandard1.3": {

--- a/src/Microsoft.Net.Http.Headers/ContentDispositionHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/ContentDispositionHeaderValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
@@ -578,12 +579,13 @@ namespace Microsoft.Net.Http.Headers
             }
 
             var decoded = new StringBuilder();
+            byte[] unescapedBytes = null;
             try
             {
                 var encoding = Encoding.GetEncoding(parts[0]);
 
                 var dataString = parts[2];
-                var unescapedBytes = new byte[dataString.Length];
+                unescapedBytes = ArrayPool<byte>.Shared.Rent(dataString.Length);
                 var unescapedBytesCount = 0;
                 for (var index = 0; index < dataString.Length; index++)
                 {
@@ -613,9 +615,17 @@ namespace Microsoft.Net.Http.Headers
             }
             catch (ArgumentException)
             {
+                if (unescapedBytes != null)
+                {
+                    ArrayPool<byte>.Shared.Return(unescapedBytes);
+                }
                 return false; // Unknown encoding or bad characters
             }
 
+            if (unescapedBytes != null)
+            {
+                ArrayPool<byte>.Shared.Return(unescapedBytes);
+            }
             output = decoded.ToString();
             return true;
         }

--- a/src/Microsoft.Net.Http.Headers/project.json
+++ b/src/Microsoft.Net.Http.Headers/project.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netstandard1.0": {
+    "netstandard1.1": {
       "dependencies": {
         "System.Collections": "4.0.11-*",
         "System.Diagnostics.Contracts": "4.0.1-*",
@@ -24,9 +24,10 @@
         "System.Resources.ResourceManager": "4.0.1-*",
         "System.Runtime.Extensions": "4.1.0-*",
         "System.Text.Encoding": "4.0.11-*",
+        "System.Buffers": "4.0.0-*"
       },
       "imports": [
-        "dotnet5.1"
+        "dotnet5.2"
       ]
     }
   }


### PR DESCRIPTION
Built on #550
Addressing Task allocations in  #553 (last commit in this PR)

ValueTask reduces Task allocation by FormReader to 1%
Post for 30,000 requests - byte[] allocations are as follows 0.5MB on rent vs 440MB on MemoryStream originally

/cc @rynowak @davidfowl @Tratcher @stephentoub 