### PR TITLE
Add AuthenticationManager.HttpContext. Clean up contructors.

### DIFF
--- a/samples/SampleApp/PooledHttpContext.cs
+++ b/samples/SampleApp/PooledHttpContext.cs
@@ -21,11 +21,11 @@ namespace SampleApp
         {
             if (_pooledHttpRequest != null)
             {
-                _pooledHttpRequest.Initialize(this, Features);
+                _pooledHttpRequest.Initialize(this);
                 return _pooledHttpRequest;
             }
 
-            return new DefaultHttpRequest(this, Features);
+            return new DefaultHttpRequest(this);
         }
 
         protected override void UninitializeHttpRequest(HttpRequest instance)
@@ -38,11 +38,11 @@ namespace SampleApp
         {
             if (_pooledHttpResponse != null)
             {
-                _pooledHttpResponse.Initialize(this, Features);
+                _pooledHttpResponse.Initialize(this);
                 return _pooledHttpResponse;
             }
 
-            return new DefaultHttpResponse(this, Features);
+            return new DefaultHttpResponse(this);
         }
 
         protected override void UninitializeHttpResponse(HttpResponse instance)

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticationManager.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticationManager.cs
@@ -16,6 +16,8 @@ namespace Microsoft.AspNetCore.Http.Authentication
         /// </summary>
         public const string AutomaticScheme = "Automatic";
 
+        public abstract HttpContext HttpContext { get; }
+
         public abstract IEnumerable<AuthenticationDescription> GetAuthenticationSchemes();
 
         public abstract Task AuthenticateAsync(AuthenticateContext context);

--- a/src/Microsoft.AspNetCore.Http/Authentication/DefaultAuthenticationManager.cs
+++ b/src/Microsoft.AspNetCore.Http/Authentication/DefaultAuthenticationManager.cs
@@ -14,22 +14,26 @@ namespace Microsoft.AspNetCore.Http.Authentication.Internal
 {
     public class DefaultAuthenticationManager : AuthenticationManager
     {
+        private HttpContext _context;
         private FeatureReferences<IHttpAuthenticationFeature> _features;
 
-        public DefaultAuthenticationManager(IFeatureCollection features)
+        public DefaultAuthenticationManager(HttpContext context)
         {
-            Initialize(features);
+            Initialize(context);
         }
 
-        public virtual void Initialize(IFeatureCollection features)
+        public virtual void Initialize(HttpContext context)
         {
-            _features = new FeatureReferences<IHttpAuthenticationFeature>(features);
+            _context = context;
+            _features = new FeatureReferences<IHttpAuthenticationFeature>(context.Features);
         }
 
         public virtual void Uninitialize()
         {
             _features = default(FeatureReferences<IHttpAuthenticationFeature>);
         }
+
+        public override HttpContext HttpContext => _context;
 
         private IHttpAuthenticationFeature HttpAuthenticationFeature =>
             _features.Fetch(ref _features.Cache, f => new HttpAuthenticationFeature());

--- a/src/Microsoft.AspNetCore.Http/DefaultHttpContext.cs
+++ b/src/Microsoft.AspNetCore.Http/DefaultHttpContext.cs
@@ -173,16 +173,16 @@ namespace Microsoft.AspNetCore.Http.Internal
         }
 
 
-        protected virtual HttpRequest InitializeHttpRequest() => new DefaultHttpRequest(this, Features);
+        protected virtual HttpRequest InitializeHttpRequest() => new DefaultHttpRequest(this);
         protected virtual void UninitializeHttpRequest(HttpRequest instance) { }
 
-        protected virtual HttpResponse InitializeHttpResponse() => new DefaultHttpResponse(this, Features);
+        protected virtual HttpResponse InitializeHttpResponse() => new DefaultHttpResponse(this);
         protected virtual void UninitializeHttpResponse(HttpResponse instance) { }
 
         protected virtual ConnectionInfo InitializeConnectionInfo() => new DefaultConnectionInfo(Features);
         protected virtual void UninitializeConnectionInfo(ConnectionInfo instance) { }
 
-        protected virtual AuthenticationManager InitializeAuthenticationManager() => new DefaultAuthenticationManager(Features);
+        protected virtual AuthenticationManager InitializeAuthenticationManager() => new DefaultAuthenticationManager(this);
         protected virtual void UninitializeAuthenticationManager(AuthenticationManager instance) { }
 
         protected virtual WebSocketManager InitializeWebSocketManager() => new DefaultWebSocketManager(Features);

--- a/src/Microsoft.AspNetCore.Http/DefaultHttpRequest.cs
+++ b/src/Microsoft.AspNetCore.Http/DefaultHttpRequest.cs
@@ -16,15 +16,15 @@ namespace Microsoft.AspNetCore.Http.Internal
         private HttpContext _context;
         private FeatureReferences<FeatureInterfaces> _features;
 
-        public DefaultHttpRequest(HttpContext context, IFeatureCollection features)
+        public DefaultHttpRequest(HttpContext context)
         {
-            Initialize(context, features);
+            Initialize(context);
         }
 
-        public virtual void Initialize(HttpContext context, IFeatureCollection features)
+        public virtual void Initialize(HttpContext context)
         {
             _context = context;
-            _features = new FeatureReferences<FeatureInterfaces>(features);
+            _features = new FeatureReferences<FeatureInterfaces>(context.Features);
         }
 
         public virtual void Uninitialize()

--- a/src/Microsoft.AspNetCore.Http/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNetCore.Http/DefaultHttpResponse.cs
@@ -15,15 +15,15 @@ namespace Microsoft.AspNetCore.Http.Internal
         private HttpContext _context;
         private FeatureReferences<FeatureInterfaces> _features;
 
-        public DefaultHttpResponse(HttpContext context, IFeatureCollection features)
+        public DefaultHttpResponse(HttpContext context)
         {
-            Initialize(context, features);
+            Initialize(context);
         }
 
-        public virtual void Initialize(HttpContext context, IFeatureCollection features)
+        public virtual void Initialize(HttpContext context)
         {
             _context = context;
-            _features = new FeatureReferences<FeatureInterfaces>(features);
+            _features = new FeatureReferences<FeatureInterfaces>(context.Features);
         }
 
         public virtual void Uninitialize()


### PR DESCRIPTION
@benaadams @muratg @HaoK 
Adding AuthenticationManager.HttpContext to mirror HttpRequest.HttpContext. We want to do some extensions on AuthenticationManager that need access to HttpContext.User.

Also cleaning up some of the constructors since they no longer need to pass both HttpContext and IFeatureCollection. We exposed HttpContext.Features directly.