### PR TITLE
Correct tests to avoid warnings and to ensure scenario is actually tested

### DIFF
--- a/src/Microsoft.AspNetCore.Owin/project.json
+++ b/src/Microsoft.AspNetCore.Owin/project.json
@@ -10,8 +10,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.AspNetCore.Http": "1.0.0-*",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-*"
+    "Microsoft.AspNetCore.Http": "1.0.0-*"
   },
   "frameworks": {
     "net451": {},

--- a/src/Microsoft.AspNetCore.Owin/project.json
+++ b/src/Microsoft.AspNetCore.Owin/project.json
@@ -10,7 +10,8 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.AspNetCore.Http": "1.0.0-*"
+    "Microsoft.AspNetCore.Http": "1.0.0-*",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-*"
   },
   "frameworks": {
     "net451": {},

--- a/test/Microsoft.AspNetCore.Owin.Tests/OwinExtensionTests.cs
+++ b/test/Microsoft.AspNetCore.Owin.Tests/OwinExtensionTests.cs
@@ -6,20 +6,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder.Internal;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Owin
 {
+    using AddMiddleware = Action<Func<
+          Func<IDictionary<string, object>, Task>,
+          Func<IDictionary<string, object>, Task>
+        >>;
     using AppFunc = Func<IDictionary<string, object>, Task>;
     using CreateMiddleware = Func<
           Func<IDictionary<string, object>, Task>,
           Func<IDictionary<string, object>, Task>
         >;
-    using AddMiddleware = Action<Func<
-          Func<IDictionary<string, object>, Task>,
-          Func<IDictionary<string, object>, Task>
-        >>;
 
     public class OwinExtensionTests
     {
@@ -87,6 +90,72 @@ namespace Microsoft.AspNetCore.Owin
             Assert.Equal(expectedServiceProvider, serviceProvider);
             Assert.True(applicationExecuted);
             Assert.Null(fakeService);
+        }
+
+        [Fact]
+        public async Task OwinDefaultNullServiceProvider()
+        {
+            var list = new List<CreateMiddleware>();
+            AddMiddleware build = list.Add;
+            IServiceProvider serviceProvider = null;
+            FakeService fakeService = null;
+            bool builderExecuted = false;
+            bool applicationExecuted = false;
+
+            var builder = build.UseBuilder(applicationBuilder =>
+            {
+                builderExecuted = true;
+                serviceProvider = applicationBuilder.ApplicationServices;
+                applicationBuilder.Run(context =>
+                {
+                    applicationExecuted = true;
+                    fakeService = context.RequestServices.GetService<FakeService>();
+                    return Task.FromResult(0);
+                });
+            });
+
+            list.Reverse();
+            await list
+                .Aggregate(notFound, (next, middleware) => middleware(next))
+                .Invoke(new Dictionary<string, object>());
+
+            Assert.True(builderExecuted);
+            Assert.NotNull(serviceProvider);
+            Assert.True(applicationExecuted);
+            Assert.Null(fakeService);
+        }
+
+        [Fact]
+        public async Task UseOwin()
+        {
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var builder = new ApplicationBuilder(serviceProvider);
+            IDictionary<string, object> environment = null;
+            var context = new DefaultHttpContext();
+
+            builder.UseOwin(addToPipeline =>
+            {
+                addToPipeline(next =>
+                {
+                    Assert.NotNull(next);
+                    return async env =>
+                    {
+                        environment = env;
+                        await next(env);
+                    };
+                });
+            });
+            await builder.Build().Invoke(context);
+
+            // Dictionary contains context but does not contain "websocket.Accept" or "websocket.AcceptAlt" keys.
+            Assert.NotNull(environment);
+            var value = Assert.Single(
+                    environment,
+                    kvp => string.Equals(typeof(HttpContext).FullName, kvp.Key, StringComparison.Ordinal))
+                .Value;
+            Assert.Equal(context, value);
+            Assert.False(environment.ContainsKey("websocket.Accept"));
+            Assert.False(environment.ContainsKey("websocket.AcceptAlt"));
         }
 
         private class FakeService

--- a/test/Microsoft.AspNetCore.Owin.Tests/OwinExtensionTests.cs
+++ b/test/Microsoft.AspNetCore.Owin.Tests/OwinExtensionTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Owin
         static AppFunc notFound = env => new Task(() => { env["owin.ResponseStatusCode"] = 404; });
 
         [Fact]
-        public void OwinConfigureServiceProviderAddsServices()
+        public async Task OwinConfigureServiceProviderAddsServices()
         {
             var list = new List<CreateMiddleware>();
             AddMiddleware build = list.Add;
@@ -45,7 +45,9 @@ namespace Microsoft.AspNetCore.Owin
             new ServiceCollection().AddSingleton(new FakeService()).BuildServiceProvider());
 
             list.Reverse();
-            list.Aggregate(notFound, (next, middleware) => middleware(next)).Invoke(new Dictionary<string, object>());
+            await list
+                .Aggregate(notFound, (next, middleware) => middleware(next))
+                .Invoke(new Dictionary<string, object>());
 
             Assert.NotNull(serviceProvider);
             Assert.NotNull(serviceProvider.GetService<FakeService>());
@@ -53,7 +55,7 @@ namespace Microsoft.AspNetCore.Owin
         }
 
         [Fact]
-        public void OwinDefaultNoServices()
+        public async Task OwinDefaultNoServices()
         {
             var list = new List<CreateMiddleware>();
             AddMiddleware build = list.Add;
@@ -77,7 +79,9 @@ namespace Microsoft.AspNetCore.Owin
             expectedServiceProvider);
 
             list.Reverse();
-            list.Aggregate(notFound, (next, middleware) => middleware(next)).Invoke(new Dictionary<string, object>());
+            await list
+                .Aggregate(notFound, (next, middleware) => middleware(next))
+                .Invoke(new Dictionary<string, object>());
 
             Assert.True(builderExecuted);
             Assert.Equal(expectedServiceProvider, serviceProvider);


### PR DESCRIPTION
- tests previously went `async` without waiting for completion