### PR TITLE
Do not buffer the request body by default when reading forms.

### DIFF
--- a/src/Microsoft.AspNetCore.Http/Features/HttpResponseFeature.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/HttpResponseFeature.cs
@@ -25,17 +25,17 @@ namespace Microsoft.AspNetCore.Http.Features.Internal
 
         public Stream Body { get; set; }
 
-        public bool HasStarted
+        public virtual bool HasStarted
         {
             get { return false; }
         }
 
-        public void OnStarting(Func<object, Task> callback, object state)
+        public virtual void OnStarting(Func<object, Task> callback, object state)
         {
             throw new NotImplementedException();
         }
 
-        public void OnCompleted(Func<object, Task> callback, object state)
+        public virtual void OnCompleted(Func<object, Task> callback, object state)
         {
             throw new NotImplementedException();
         }

--- a/test/Microsoft.AspNetCore.Http.Tests/FakeResponseFeature.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/FakeResponseFeature.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features.Internal;
+
+namespace Microsoft.AspNetCore.Http.Features.Internal
+{
+    public class FakeResponseFeature : HttpResponseFeature
+    {
+        List<Tuple<Func<object, Task>, object>> _onCompletedCallbacks = new List<Tuple<Func<object, Task>, object>>();
+
+        public override void OnCompleted(Func<object, Task> callback, object state)
+        {
+            _onCompletedCallbacks.Add(new Tuple<Func<object, Task>, object>(callback, state));
+        }
+
+        public async Task CompleteAsync()
+        {
+            var callbacks = _onCompletedCallbacks;
+            _onCompletedCallbacks = null;
+            foreach (var callback in callbacks)
+            {
+                await callback.Item1(callback.Item2);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Http.Tests/NonSeekableReadStream.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/NonSeekableReadStream.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Http.Features.Internal
+{
+    public class NonSeekableReadStream : Stream
+    {
+        private Stream _inner;
+
+        public NonSeekableReadStream(byte[] data)
+            : this(new MemoryStream(data))
+        {
+        }
+
+        public NonSeekableReadStream(Stream inner)
+        {
+            _inner = inner;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _inner.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _inner.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
#578 @rynowak @muratg @lodejard 
We still have to buffer multipart file bodies, but we can disable buffering for the full request body.