### PR TITLE
Fix regressions in FormReader / FileBufferingReadStream.

### DIFF
--- a/test/Microsoft.AspNetCore.Http.Tests/Features/FormFeatureTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/Features/FormFeatureTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -346,6 +347,130 @@ namespace Microsoft.AspNetCore.Http.Features
             }
 
             await responseFeature.CompleteAsync();
+        }
+
+        [Theory]
+        // FileBufferingReadStream transitions to disk storage after 30kb, and stops pooling buffers at 1mb.
+        [InlineData(true, 1024)]
+        [InlineData(false, 1024)]
+        [InlineData(true, 40 * 1024)]
+        [InlineData(false, 40 * 1024)]
+        [InlineData(true, 4 * 1024 * 1024)]
+        [InlineData(false, 4 * 1024 * 1024)]
+        public async Task ReadFormAsync_MultipartWithFieldAndMediumFile_ReturnsParsedFormCollection(bool bufferRequest, int fileSize)
+        {
+            var fileContents = CreateFile(fileSize);
+            var formContent = CreateMultipartWithFormAndFile(fileContents);
+            var context = new DefaultHttpContext();
+            var responseFeature = new FakeResponseFeature();
+            context.Features.Set<IHttpResponseFeature>(responseFeature);
+            context.Request.ContentType = MultipartContentType;
+            context.Request.Body = new NonSeekableReadStream(formContent);
+
+            if (bufferRequest)
+            {
+                context.Request.EnableRewind();
+            }
+
+            // Not cached yet
+            var formFeature = context.Features.Get<IFormFeature>();
+            Assert.Null(formFeature);
+
+            var formCollection = await context.Request.ReadFormAsync();
+
+            Assert.NotNull(formCollection);
+
+            // Cached
+            formFeature = context.Features.Get<IFormFeature>();
+            Assert.NotNull(formFeature);
+            Assert.NotNull(formFeature.Form);
+            Assert.Same(formFeature.Form, formCollection);
+            Assert.Same(formCollection, context.Request.Form);
+
+            // Content
+            Assert.Equal(1, formCollection.Count);
+            Assert.Equal("Foo", formCollection["description"]);
+
+            Assert.NotNull(formCollection.Files);
+            Assert.Equal(1, formCollection.Files.Count);
+
+            var file = formCollection.Files["myfile1"];
+            Assert.Equal("text/html", file.ContentType);
+            Assert.Equal(@"form-data; name=""myfile1""; filename=""temp.html""", file.ContentDisposition);
+            using (var body = file.OpenReadStream())
+            {
+                Assert.True(body.CanSeek);
+                CompareStreams(fileContents, body);
+            }
+
+            await responseFeature.CompleteAsync();
+        }
+
+        private Stream CreateFile(int size)
+        {
+            var stream = new MemoryStream(size);
+            var bytes = Encoding.ASCII.GetBytes("HelloWorld_ABCDEFGHIJKLMNOPQRSTUVWXYZ.abcdefghijklmnopqrstuvwxyz,0123456789;");
+            int written = 0;
+            while (written < size)
+            {
+                var toWrite = Math.Min(size - written, bytes.Length);
+                stream.Write(bytes, 0, toWrite);
+                written += toWrite;
+            }
+            stream.Position = 0;
+            return stream;
+        }
+
+        private Stream CreateMultipartWithFormAndFile(Stream fileContents)
+        {
+            var stream = new MemoryStream();
+            var header =
+"--WebKitFormBoundary5pDRpGheQXaM8k3T\r\n" +
+"Content-Disposition: form-data; name=\"description\"\r\n" +
+"\r\n" +
+"Foo\r\n" +
+"--WebKitFormBoundary5pDRpGheQXaM8k3T\r\n" +
+"Content-Disposition: form-data; name=\"myfile1\"; filename=\"temp.html\"\r\n" +
+"Content-Type: text/html\r\n" +
+"\r\n";
+            var footer =
+"\r\n--WebKitFormBoundary5pDRpGheQXaM8k3T--";
+
+            var bytes = Encoding.ASCII.GetBytes(header);
+            stream.Write(bytes, 0, bytes.Length);
+
+            fileContents.CopyTo(stream);
+            fileContents.Position = 0;
+
+            bytes = Encoding.ASCII.GetBytes(footer);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Position = 0;
+            return stream;
+        }
+
+        private void CompareStreams(Stream streamA, Stream streamB)
+        {
+            Assert.Equal(streamA.Length, streamB.Length);
+            byte[] bytesA = new byte[1024], bytesB = new byte[1024];
+            var readA = streamA.Read(bytesA, 0, bytesA.Length);
+            var readB = streamB.Read(bytesB, 0, bytesB.Length);
+            Assert.Equal(readA, readB);
+            var loops = 0;
+            while (readA > 0)
+            {
+                for (int i = 0; i < readA; i++)
+                {
+                    if (bytesA[i] != bytesB[i])
+                    {
+                        throw new Exception($"Value mismatch at loop {loops}, index {i}; A:{bytesA[i]}, B:{bytesB[i]}");
+                    }
+                }
+
+                readA = streamA.Read(bytesA, 0, bytesA.Length);
+                readB = streamB.Read(bytesB, 0, bytesB.Length);
+                Assert.Equal(readA, readB);
+                loops++;
+            }
         }
     }
 }


### PR DESCRIPTION
#605 @davidfowl @muratg @benaadams @BrennanConroy 

The recent perf changes caused two regressions in the FileBufferingReadStream used by form reader. The one reported in #605 is that most of the data buffered in memory gets discarded when transitioning to the file buffer. This happened because Write was accidentally given the wrong length when I cleaned up some of @benaadams's code.

The other regression was that the constructor only rented buffers if the in-memory threshold was less than 1mb, but Read always assumed it was using rented buffers. This would have caused ArgumentNullExceptions trying to use an uninitialized buffer. The fix is to rent a buffer when needed and do a manual CopyTo loop.

Compare with https://github.com/aspnet/HttpAbstractions/commit/bd60507dcd317f2c1f42da37afd9dbc928f50928#diff-6bee66e850efacd8fe96daae334fa1c5R192