### PR TITLE
Prevent double flush in HttpResponseStreamWriter.

### DIFF
--- a/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
@@ -302,12 +302,12 @@ namespace Microsoft.AspNetCore.WebUtilities
                 0,
                 flush: flushEncoder);
 
+            _charBufferCount = 0;
+
             if (count > 0)
             {
                 _stream.Write(_byteBuffer, 0, count);
             }
-
-            _charBufferCount = 0;
         }
 
         // Note: our FlushInternalAsync method does NOT flush the underlying stream. This would result in
@@ -327,12 +327,12 @@ namespace Microsoft.AspNetCore.WebUtilities
                 0,
                 flush: flushEncoder);
 
+            _charBufferCount = 0;
+
             if (count > 0)
             {
                 await _stream.WriteAsync(_byteBuffer, 0, count);
             }
-
-            _charBufferCount = 0;
         }
 
         private void CopyToCharBuffer(string value, ref int index, ref int count)


### PR DESCRIPTION
@muratg @rynowak 

I found this while investigating strange exceptions in the MusicStore WebListener tests.  [MVC](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewExecutor.cs#L163-L183) flushes the writer and then disposes it. However, if there's an exception from the flush (an IOException in this case) then _charBufferCount doesn't get reset and Dispose tries to flush the same data again. This causes a secondary exception (ObjectDisposedException) that masks the first exception, making the original issue harder to debug.

This is not an RC2 candidate, I can wait to merge it until after we branch for release.