### PR TITLE
Make the form body limits configurable.

### DIFF
--- a/src/Microsoft.AspNetCore.Http/Features/FormOptions.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/FormOptions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace Microsoft.AspNetCore.Http.Features
+{
+    public class FormOptions
+    {
+        public const int DefaultMemoryBufferThreshold = 1024 * 64;
+        public const int DefaultBufferBodyLengthLimit = 1024 * 1024 * 128;
+        public const int DefaultMultipartBoundaryLengthLimit = 128;
+        public const long DefaultMultipartBodyLengthLimit = 1024 * 1024 * 128;
+
+        public bool BufferBody { get; set; } = false;
+        public int MemoryBufferThreshold { get; set; } = DefaultMemoryBufferThreshold;
+        public long BufferBodyLengthLimit { get; set; } = DefaultBufferBodyLengthLimit;
+        public int KeyCountLimit { get; set; } = FormReader.DefaultKeyCountLimit;
+        public int KeyLengthLimit { get; set; } = FormReader.DefaultKeyLengthLimit;
+        public int ValueLengthLimit { get; set; } = FormReader.DefaultValueLengthLimit;
+        public int MultipartBoundaryLengthLimit { get; set; } = DefaultMultipartBoundaryLengthLimit;
+        public int MultipartHeadersCountLimit { get; set; } = MultipartReader.DefaultHeadersCountLimit;
+        public int MultipartHeadersLengthLimit { get; set; } = MultipartReader.DefaultHeadersLengthLimit;
+        public long MultipartBodyLengthLimit { get; set; } = DefaultMultipartBodyLengthLimit;
+    }
+}

--- a/src/Microsoft.AspNetCore.Http/Internal/BufferingHelper.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/BufferingHelper.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Http.Internal
             }
         }
 
-        public static HttpRequest EnableRewind(this HttpRequest request, int bufferThreshold = DefaultBufferThreshold)
+        public static HttpRequest EnableRewind(this HttpRequest request, int bufferThreshold = DefaultBufferThreshold, long? bufferLimit = null)
         {
             if (request == null)
             {
@@ -48,14 +48,15 @@ namespace Microsoft.AspNetCore.Http.Internal
             var body = request.Body;
             if (!body.CanSeek)
             {
-                var fileStream = new FileBufferingReadStream(body, bufferThreshold, _getTempDirectory);
+                var fileStream = new FileBufferingReadStream(body, bufferThreshold, bufferLimit, _getTempDirectory);
                 request.Body = fileStream;
                 request.HttpContext.Response.RegisterForDispose(fileStream);
             }
             return request;
         }
 
-        public static MultipartSection EnableRewind(this MultipartSection section, Action<IDisposable> registerForDispose, int bufferThreshold = DefaultBufferThreshold)
+        public static MultipartSection EnableRewind(this MultipartSection section, Action<IDisposable> registerForDispose,
+            int bufferThreshold = DefaultBufferThreshold, long? bufferLimit = null)
         {
             if (section == null)
             {
@@ -69,7 +70,7 @@ namespace Microsoft.AspNetCore.Http.Internal
             var body = section.Body;
             if (!body.CanSeek)
             {
-                var fileStream = new FileBufferingReadStream(body, bufferThreshold, _getTempDirectory);
+                var fileStream = new FileBufferingReadStream(body, bufferThreshold, bufferLimit, _getTempDirectory);
                 section.Body = fileStream;
                 registerForDispose(fileStream);
             }

--- a/src/Microsoft.AspNetCore.Http/RequestFormReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Http/RequestFormReaderExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public static class RequestFormReaderExtensions
+    {
+        /// <summary>
+        /// Read the request body as a form with the given options. These options will only be used
+        /// if the form has not already been read.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="options">Options for reading the form.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The parsed form.</returns>
+        public static Task<IFormCollection> ReadFormAsync(this HttpRequest request, FormOptions options,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (!request.HasFormContentType)
+            {
+                throw new InvalidOperationException("Incorrect Content-Type: " + request.ContentType);
+            }
+
+            var features = request.HttpContext.Features;
+            var formFeature = features.Get<IFormFeature>();
+            if (formFeature == null || formFeature.Form == null)
+            {
+                // We haven't read the form yet, replace the reader with one using our own options.
+                features.Set<IFormFeature>(new FormFeature(request, options));
+            }
+            return request.ReadFormAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Http/project.json
+++ b/src/Microsoft.AspNetCore.Http/project.json
@@ -21,6 +21,7 @@
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.0-*",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0-*",
     "Microsoft.Extensions.ObjectPool": "1.0.0-*",
+    "Microsoft.Extensions.Options": "1.0.0-*",
     "Microsoft.Net.Http.Headers": "1.0.0-*",
     "System.Buffers": "4.0.0-*"
   },

--- a/src/Microsoft.AspNetCore.WebUtilities/BufferedReadStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/BufferedReadStream.cs
@@ -352,7 +352,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     if (builder.Length > lengthLimit)
                     {
-                        throw new InvalidOperationException("Line length limit exceeded: " + lengthLimit.ToString());
+                        throw new InvalidDataException($"Line length limit {lengthLimit} exceeded.");
                     }
                     ProcessLineChar(builder, ref foundCR, ref foundCRLF);
                 }
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     if (builder.Length > lengthLimit)
                     {
-                        throw new InvalidOperationException("Line length limit exceeded: " + lengthLimit.ToString());
+                        throw new InvalidDataException($"Line length limit {lengthLimit} exceeded.");
                     }
 
                     ProcessLineChar(builder, ref foundCR, ref foundCRLF);

--- a/src/Microsoft.AspNetCore.WebUtilities/KeyValueAccumulator.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/KeyValueAccumulator.cs
@@ -63,6 +63,8 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         public bool HasValues => _accumulator != null;
 
+        public int Count => _accumulator?.Count ?? 0;
+
         public Dictionary<string, StringValues> GetResults()
         {
             if (_expandingAccumulator != null)

--- a/src/Microsoft.AspNetCore.WebUtilities/MultipartReaderStream.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/MultipartReaderStream.cs
@@ -57,6 +57,8 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         public bool FinalBoundaryFound { get; private set; }
 
+        public long? LengthLimit { get; set; }
+
         public override bool CanRead
         {
             get { return true; }
@@ -159,6 +161,10 @@ namespace Microsoft.AspNetCore.WebUtilities
             if (_observedLength < _position)
             {
                 _observedLength = _position;
+                if (LengthLimit.HasValue && _observedLength > LengthLimit.Value)
+                {
+                    throw new InvalidDataException($"Multipart body length limit {LengthLimit.Value} exceeded.");
+                }
             }
             return read;
         }

--- a/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/StreamHelperExtensions.cs
@@ -14,19 +14,32 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         public static Task DrainAsync(this Stream stream, CancellationToken cancellationToken)
         {
-            return stream.DrainAsync(ArrayPool<byte>.Shared, cancellationToken);
+            return stream.DrainAsync(ArrayPool<byte>.Shared, null, cancellationToken);
         }
 
-        public static async Task DrainAsync(this Stream stream, ArrayPool<byte> bytePool, CancellationToken cancellationToken)
+        public static Task DrainAsync(this Stream stream, long? limit, CancellationToken cancellationToken)
+        {
+            return stream.DrainAsync(ArrayPool<byte>.Shared, limit, cancellationToken);
+        }
+
+        public static async Task DrainAsync(this Stream stream, ArrayPool<byte> bytePool, long? limit, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var buffer = bytePool.Rent(_maxReadBufferSize);
+            long total = 0;
             try
             {
-                while (await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken) > 0)
+                var read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+                while (read > 0)
                 {
                     // Not all streams support cancellation directly.
                     cancellationToken.ThrowIfCancellationRequested();
+                    if (limit.HasValue && limit.Value - total < read)
+                    {
+                        throw new InvalidDataException($"The stream exceeded the data limit {limit.Value}.");
+                    }
+                    total += read;
+                    read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
                 }
             }
             finally

--- a/test/Microsoft.AspNetCore.Http.Tests/Features/FormFeatureTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/Features/FormFeatureTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Internal;
-using Microsoft.AspNetCore.WebUtilities;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Http.Features
@@ -26,14 +24,8 @@ namespace Microsoft.AspNetCore.Http.Features
             context.Request.ContentType = "application/x-www-form-urlencoded; charset=utf-8";
             context.Request.Body = new NonSeekableReadStream(formContent);
 
-            if (bufferRequest)
-            {
-                context.Request.EnableRewind();
-            }
-
-            // Not cached yet
-            var formFeature = context.Features.Get<IFormFeature>();
-            Assert.Null(formFeature);
+            IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
+            context.Features.Set<IFormFeature>(formFeature);
 
             var formCollection = await context.Request.ReadFormAsync();
 
@@ -53,80 +45,6 @@ namespace Microsoft.AspNetCore.Http.Features
 
             // Cleanup
             await responseFeature.CompleteAsync();
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ReadFormAsync_EmptyKeyAtEndAllowed(bool bufferRequest)
-        {
-            var formContent = Encoding.UTF8.GetBytes("=bar");
-            Stream body = new MemoryStream(formContent);
-            if (!bufferRequest)
-            {
-                body = new NonSeekableReadStream(body);
-            }
-
-            var formCollection = await FormReader.ReadFormAsync(body);
-
-            Assert.Equal("bar", formCollection[""].FirstOrDefault());
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ReadFormAsync_EmptyKeyWithAdditionalEntryAllowed(bool bufferRequest)
-        {
-            var formContent = Encoding.UTF8.GetBytes("=bar&baz=2");
-            Stream body = new MemoryStream(formContent);
-            if (!bufferRequest)
-            {
-                body = new NonSeekableReadStream(body);
-            }
-
-            var formCollection = await FormReader.ReadFormAsync(body);
-
-            Assert.Equal("bar", formCollection[""].FirstOrDefault());
-            Assert.Equal("2", formCollection["baz"].FirstOrDefault());
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ReadFormAsync_EmptyValuedAtEndAllowed(bool bufferRequest)
-        {
-            // Arrange
-            var formContent = Encoding.UTF8.GetBytes("foo=");
-            Stream body = new MemoryStream(formContent);
-            if (!bufferRequest)
-            {
-                body = new NonSeekableReadStream(body);
-            }
-
-            var formCollection = await FormReader.ReadFormAsync(body);
-
-            // Assert
-            Assert.Equal("", formCollection["foo"].FirstOrDefault());
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ReadFormAsync_EmptyValuedWithAdditionalEntryAllowed(bool bufferRequest)
-        {
-            // Arrange
-            var formContent = Encoding.UTF8.GetBytes("foo=&baz=2");
-            Stream body = new MemoryStream(formContent);
-            if (!bufferRequest)
-            {
-                body = new NonSeekableReadStream(body);
-            }
-
-            var formCollection = await FormReader.ReadFormAsync(body);
-
-            // Assert
-            Assert.Equal("", formCollection["foo"].FirstOrDefault());
-            Assert.Equal("2", formCollection["baz"].FirstOrDefault());
         }
 
         private const string MultipartContentType = "multipart/form-data; boundary=WebKitFormBoundary5pDRpGheQXaM8k3T";
@@ -170,14 +88,8 @@ namespace Microsoft.AspNetCore.Http.Features
             context.Request.ContentType = MultipartContentType;
             context.Request.Body = new NonSeekableReadStream(formContent);
 
-            if (bufferRequest)
-            {
-                context.Request.EnableRewind();
-            }
-
-            // Not cached yet
-            var formFeature = context.Features.Get<IFormFeature>();
-            Assert.Null(formFeature);
+            IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
+            context.Features.Set<IFormFeature>(formFeature);
 
             var formCollection = context.Request.Form;
 
@@ -211,14 +123,8 @@ namespace Microsoft.AspNetCore.Http.Features
             context.Request.ContentType = MultipartContentType;
             context.Request.Body = new NonSeekableReadStream(formContent);
 
-            if (bufferRequest)
-            {
-                context.Request.EnableRewind();
-            }
-
-            // Not cached yet
-            var formFeature = context.Features.Get<IFormFeature>();
-            Assert.Null(formFeature);
+            IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
+            context.Features.Set<IFormFeature>(formFeature);
 
             var formCollection = context.Request.Form;
 
@@ -254,14 +160,8 @@ namespace Microsoft.AspNetCore.Http.Features
             context.Request.ContentType = MultipartContentType;
             context.Request.Body = new NonSeekableReadStream(formContent);
 
-            if (bufferRequest)
-            {
-                context.Request.EnableRewind();
-            }
-
-            // Not cached yet
-            var formFeature = context.Features.Get<IFormFeature>();
-            Assert.Null(formFeature);
+            IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
+            context.Features.Set<IFormFeature>(formFeature);
 
             var formCollection = await context.Request.ReadFormAsync();
 
@@ -308,14 +208,8 @@ namespace Microsoft.AspNetCore.Http.Features
             context.Request.ContentType = MultipartContentType;
             context.Request.Body = new NonSeekableReadStream(formContent);
 
-            if (bufferRequest)
-            {
-                context.Request.EnableRewind();
-            }
-
-            // Not cached yet
-            var formFeature = context.Features.Get<IFormFeature>();
-            Assert.Null(formFeature);
+            IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
+            context.Features.Set<IFormFeature>(formFeature);
 
             var formCollection = await context.Request.ReadFormAsync();
 
@@ -367,14 +261,8 @@ namespace Microsoft.AspNetCore.Http.Features
             context.Request.ContentType = MultipartContentType;
             context.Request.Body = new NonSeekableReadStream(formContent);
 
-            if (bufferRequest)
-            {
-                context.Request.EnableRewind();
-            }
-
-            // Not cached yet
-            var formFeature = context.Features.Get<IFormFeature>();
-            Assert.Null(formFeature);
+            IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
+            context.Features.Set<IFormFeature>(formFeature);
 
             var formCollection = await context.Request.ReadFormAsync();
 

--- a/test/Microsoft.AspNetCore.Http.Tests/HttpContextFactoryTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/HttpContextFactoryTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.ObjectPool;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Http
@@ -14,7 +15,7 @@ namespace Microsoft.AspNetCore.Http
         {
             // Arrange
             var accessor = new HttpContextAccessor();
-            var contextFactory = new HttpContextFactory(new DefaultObjectPoolProvider(), accessor);
+            var contextFactory = new HttpContextFactory(new DefaultObjectPoolProvider(), Options.Create(new FormOptions()), accessor);
 
             // Act
             var context = contextFactory.Create(new FeatureCollection());
@@ -27,7 +28,7 @@ namespace Microsoft.AspNetCore.Http
         public void AllowsCreatingContextWithoutSettingAccessor()
         {
             // Arrange
-            var contextFactory = new HttpContextFactory(new DefaultObjectPoolProvider());
+            var contextFactory = new HttpContextFactory(new DefaultObjectPoolProvider(), Options.Create(new FormOptions()));
 
             // Act & Assert
             var context = contextFactory.Create(new FeatureCollection());

--- a/test/Microsoft.AspNetCore.WebUtilities.Tests/FileBufferingReadStreamTests.cs
+++ b/test/Microsoft.AspNetCore.WebUtilities.Tests/FileBufferingReadStreamTests.cs
@@ -1,0 +1,294 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.WebUtilities
+{
+    public class FileBufferingReadStreamTests
+    {
+        private Stream MakeStream(int size)
+        {
+            // TODO: Fill with random data? Make readonly?
+            return new MemoryStream(new byte[size]);
+        }
+
+        [Fact]
+        public void FileBufferingReadStream_Properties_ExpectedValues()
+        {
+            var inner = MakeStream(1024 * 2);
+            using (var stream = new FileBufferingReadStream(inner, 1024, null, Directory.GetCurrentDirectory()))
+            {
+                Assert.True(stream.CanRead);
+                Assert.True(stream.CanSeek);
+                Assert.False(stream.CanWrite);
+                Assert.Equal(0, stream.Length); // Nothing buffered yet
+                Assert.Equal(0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+            }
+        }
+
+        [Fact]
+        public void FileBufferingReadStream_SyncReadUnderThreshold_DoesntCreateFile()
+        {
+            var inner = MakeStream(1024 * 2);
+            using (var stream = new FileBufferingReadStream(inner, 1024 * 3, null, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[1000];
+                var read0 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read1 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Length);
+                Assert.Equal(read0 + read1, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read2 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(inner.Length - read0 - read1, read2);
+                Assert.Equal(read0 + read1 + read2, stream.Length);
+                Assert.Equal(read0 + read1 + read2, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read3 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(0, read3);
+            }
+        }
+
+        [Fact]
+        public void FileBufferingReadStream_SyncReadOverThreshold_CreatesFile()
+        {
+            var inner = MakeStream(1024 * 2);
+            string tempFileName;
+            using (var stream = new FileBufferingReadStream(inner, 1024, null, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[1000];
+                var read0 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read1 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Length);
+                Assert.Equal(read0 + read1, stream.Position);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                tempFileName = stream.TempFileName;
+                Assert.True(File.Exists(tempFileName));
+
+                var read2 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(inner.Length - read0 - read1, read2);
+                Assert.Equal(read0 + read1 + read2, stream.Length);
+                Assert.Equal(read0 + read1 + read2, stream.Position);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                Assert.True(File.Exists(tempFileName));
+
+                var read3 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(0, read3);
+            }
+
+            Assert.False(File.Exists(tempFileName));
+        }
+
+        [Fact]
+        public void FileBufferingReadStream_SyncReadWithInMemoryLimit_EnforcesLimit()
+        {
+            var inner = MakeStream(1024 * 2);
+            using (var stream = new FileBufferingReadStream(inner, 1024, 900, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[500];
+                var read0 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var exception = Assert.Throws<IOException>(() => stream.Read(bytes, 0, bytes.Length));
+                Assert.Equal("Buffer limit exceeded.", exception.Message);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+                Assert.False(File.Exists(stream.TempFileName));
+            }
+        }
+
+        [Fact]
+        public void FileBufferingReadStream_SyncReadWithOnDiskLimit_EnforcesLimit()
+        {
+            var inner = MakeStream(1024 * 2);
+            string tempFileName;
+            using (var stream = new FileBufferingReadStream(inner, 512, 1024, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[500];
+                var read0 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read1 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Length);
+                Assert.Equal(read0 + read1, stream.Position);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                tempFileName = stream.TempFileName;
+                Assert.True(File.Exists(tempFileName));
+
+                var exception = Assert.Throws<IOException>(() => stream.Read(bytes, 0, bytes.Length));
+                Assert.Equal("Buffer limit exceeded.", exception.Message);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                Assert.False(File.Exists(tempFileName));
+            }
+
+            Assert.False(File.Exists(tempFileName));
+        }
+
+        ///////////////////
+
+        [Fact]
+        public async Task FileBufferingReadStream_AsyncReadUnderThreshold_DoesntCreateFile()
+        {
+            var inner = MakeStream(1024 * 2);
+            using (var stream = new FileBufferingReadStream(inner, 1024 * 3, null, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[1000];
+                var read0 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read1 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Length);
+                Assert.Equal(read0 + read1, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read2 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(inner.Length - read0 - read1, read2);
+                Assert.Equal(read0 + read1 + read2, stream.Length);
+                Assert.Equal(read0 + read1 + read2, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read3 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(0, read3);
+            }
+        }
+
+        [Fact]
+        public async Task FileBufferingReadStream_AsyncReadOverThreshold_CreatesFile()
+        {
+            var inner = MakeStream(1024 * 2);
+            string tempFileName;
+            using (var stream = new FileBufferingReadStream(inner, 1024, null, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[1000];
+                var read0 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read1 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Length);
+                Assert.Equal(read0 + read1, stream.Position);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                tempFileName = stream.TempFileName;
+                Assert.True(File.Exists(tempFileName));
+
+                var read2 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(inner.Length - read0 - read1, read2);
+                Assert.Equal(read0 + read1 + read2, stream.Length);
+                Assert.Equal(read0 + read1 + read2, stream.Position);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                Assert.True(File.Exists(tempFileName));
+
+                var read3 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(0, read3);
+            }
+
+            Assert.False(File.Exists(tempFileName));
+        }
+
+        [Fact]
+        public async Task FileBufferingReadStream_AsyncReadWithInMemoryLimit_EnforcesLimit()
+        {
+            var inner = MakeStream(1024 * 2);
+            using (var stream = new FileBufferingReadStream(inner, 1024, 900, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[500];
+                var read0 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var exception = await Assert.ThrowsAsync<IOException>(() => stream.ReadAsync(bytes, 0, bytes.Length));
+                Assert.Equal("Buffer limit exceeded.", exception.Message);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+                Assert.False(File.Exists(stream.TempFileName));
+            }
+        }
+
+        [Fact]
+        public async Task FileBufferingReadStream_AsyncReadWithOnDiskLimit_EnforcesLimit()
+        {
+            var inner = MakeStream(1024 * 2);
+            string tempFileName;
+            using (var stream = new FileBufferingReadStream(inner, 512, 1024, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[500];
+                var read0 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read1 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Length);
+                Assert.Equal(read0 + read1, stream.Position);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                tempFileName = stream.TempFileName;
+                Assert.True(File.Exists(tempFileName));
+
+                var exception = await Assert.ThrowsAsync<IOException>(() => stream.ReadAsync(bytes, 0, bytes.Length));
+                Assert.Equal("Buffer limit exceeded.", exception.Message);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                Assert.False(File.Exists(tempFileName));
+            }
+
+            Assert.False(File.Exists(tempFileName));
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebUtilities.Tests/FormReaderTests.cs
+++ b/test/Microsoft.AspNetCore.WebUtilities.Tests/FormReaderTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.WebUtilities
+{
+    public class FormReaderTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_EmptyKeyAtEndAllowed(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "=bar");
+
+            var formCollection = await new FormReader(body).ReadFormAsync();
+
+            Assert.Equal("bar", formCollection[""].ToString());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_EmptyKeyWithAdditionalEntryAllowed(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "=bar&baz=2");
+
+            var formCollection = await new FormReader(body).ReadFormAsync();
+
+            Assert.Equal("bar", formCollection[""].ToString());
+            Assert.Equal("2", formCollection["baz"].ToString());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_EmptyValuedAtEndAllowed(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "foo=");
+
+            var formCollection = await new FormReader(body).ReadFormAsync();
+
+            Assert.Equal("", formCollection["foo"].ToString());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_EmptyValuedWithAdditionalEntryAllowed(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "foo=&baz=2");
+
+            var formCollection = await new FormReader(body).ReadFormAsync();
+
+            Assert.Equal("", formCollection["foo"].ToString());
+            Assert.Equal("2", formCollection["baz"].ToString());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_KeyCountLimitMet_Success(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "foo=1&bar=2&baz=3&baz=4");
+
+            var formCollection = await new FormReader(body) { KeyCountLimit = 3 }.ReadFormAsync();
+
+            Assert.Equal("1", formCollection["foo"].ToString());
+            Assert.Equal("2", formCollection["bar"].ToString());
+            Assert.Equal("3,4", formCollection["baz"].ToString());
+            Assert.Equal(3, formCollection.Count);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_KeyCountLimitExceeded_Throw(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "foo=1&baz=2&bar=3&baz=4&baf=5");
+
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                () => new FormReader(body) { KeyCountLimit = 3 }.ReadFormAsync());
+            Assert.Equal("Form key count limit 3 exceeded.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_KeyLengthLimitMet_Success(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "foo=1&bar=2&baz=3&baz=4");
+
+            var formCollection = await new FormReader(body) { KeyLengthLimit = 10 }.ReadFormAsync();
+
+            Assert.Equal("1", formCollection["foo"].ToString());
+            Assert.Equal("2", formCollection["bar"].ToString());
+            Assert.Equal("3,4", formCollection["baz"].ToString());
+            Assert.Equal(3, formCollection.Count);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_KeyLengthLimitExceeded_Throw(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "foo=1&baz1234567890=2");
+
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                () => new FormReader(body) { KeyLengthLimit = 10 }.ReadFormAsync());
+            Assert.Equal("Form key or value length limit 10 exceeded.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_ValueLengthLimitMet_Success(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "foo=1&bar=1234567890&baz=3&baz=4");
+
+            var formCollection = await new FormReader(body) { ValueLengthLimit = 10 }.ReadFormAsync();
+
+            Assert.Equal("1", formCollection["foo"].ToString());
+            Assert.Equal("1234567890", formCollection["bar"].ToString());
+            Assert.Equal("3,4", formCollection["baz"].ToString());
+            Assert.Equal(3, formCollection.Count);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFormAsync_ValueLengthLimitExceeded_Throw(bool bufferRequest)
+        {
+            var body = MakeStream(bufferRequest, "foo=1&baz=1234567890123");
+
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                () => new FormReader(body) { ValueLengthLimit = 10 }.ReadFormAsync());
+            Assert.Equal("Form key or value length limit 10 exceeded.", exception.Message);
+        }
+
+        private static Stream MakeStream(bool bufferRequest, string text)
+        {
+            var formContent = Encoding.UTF8.GetBytes(text);
+            Stream body = new MemoryStream(formContent);
+            if (!bufferRequest)
+            {
+                body = new NonSeekableReadStream(body);
+            }
+            return body;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebUtilities.Tests/NonSeekableReadStream.cs
+++ b/test/Microsoft.AspNetCore.WebUtilities.Tests/NonSeekableReadStream.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.WebUtilities
+{
+    public class NonSeekableReadStream : Stream
+    {
+        private Stream _inner;
+
+        public NonSeekableReadStream(byte[] data)
+            : this(new MemoryStream(data))
+        {
+        }
+
+        public NonSeekableReadStream(Stream inner)
+        {
+            _inner = inner;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _inner.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _inner.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
@DamianEdwards @Eilon Please approve for RC2 per @blowdart's request.

@blowdart This enables the developer to configure form parsing settings and limits in Startup:
```c#
services.Configure<FormOptions>(options =>
{
  options.BufferBody = true,
});
```
And override them on a per request basis by doing:
```c#
var form = await httpContext.Request.ReadAsync(new FormOptions() { BufferBody = false });
```
The catch is that you can't override the settings if someone before you in the pipeline has already read the form.

There will be follow up discussion with MVC on how to easily configure this per Action, how to make anti-forgery honor it, and how to tell MVC not to read the form at all so you can stream large file uploads without buffering.