### PR TITLE
Add RawTarget property to IHttpRequestFeature (#596)

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Features/IHttpRequestFeature.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/IHttpRequestFeature.cs
@@ -49,6 +49,17 @@ namespace Microsoft.AspNetCore.Http.Features
         string QueryString { get; set; }
 
         /// <summary>
+        /// The request target as it was sent in the HTTP request. This property contains the
+        /// raw path and full query, as well as other request targets such as * for OPTIONS
+        /// requests (https://tools.ietf.org/html/rfc7230#section-5.3).
+        /// </summary>
+        /// <remarks>
+        /// This property is not used internally for routing or authorization decisions. It has not
+        /// been UrlDecoded and care should be taken in its use.
+        /// </remarks>
+        string RawTarget { get; set; }
+
+        /// <summary>
         /// Headers included in the request, aggregated by header name. The values are not split
         /// or merged across header lines. E.g. The following headers:
         /// HeaderA: value1, value2

--- a/src/Microsoft.AspNetCore.Http/Features/HttpRequestFeature.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/HttpRequestFeature.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.Http.Features
             PathBase = string.Empty;
             Path = string.Empty;
             QueryString = string.Empty;
+            RawTarget = string.Empty;
         }
 
         public string Protocol { get; set; }
@@ -25,6 +26,7 @@ namespace Microsoft.AspNetCore.Http.Features
         public string PathBase { get; set; }
         public string Path { get; set; }
         public string QueryString { get; set; }
+        public string RawTarget { get; set; }
         public IHeaderDictionary Headers { get; set; }
         public Stream Body { get; set; }
     }

--- a/src/Microsoft.AspNetCore.Owin/OwinFeatureCollection.cs
+++ b/src/Microsoft.AspNetCore.Owin/OwinFeatureCollection.cs
@@ -102,6 +102,12 @@ namespace Microsoft.AspNetCore.Owin
             set { Prop(OwinConstants.RequestQueryString, Utilities.RemoveQuestionMark(value)); }
         }
 
+        string IHttpRequestFeature.RawTarget
+        {
+            get { return string.Empty; }
+            set { throw new NotSupportedException(); }
+        }
+
         IHeaderDictionary IHttpRequestFeature.Headers
         {
             get { return Utilities.MakeHeaderDictionary(Prop<IDictionary<string, string[]>>(OwinConstants.RequestHeaders)); }


### PR DESCRIPTION
https://github.com/aspnet/HttpAbstractions/issues/596

Let me know if I'm missing anything on this repo.

Once this is merged I need to change:

* Kestrel
* WebListener
* What else? :grin: 

Do you think `RawTarget` is a good name for the property? I didn't want to use `Uri`, `Url`, or anything like that since this is called "target" in the RFCs.

cc @Tratcher @halter73 @JunTaoLuo @blowdart  @davidfowl 