### PR TITLE
Fix PathString over-encoding

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Abstractions/Internal/PathStringHelper.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Internal/PathStringHelper.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Http.Internal
+{
+    internal class PathStringHelper
+    {
+        private static bool[] ValidPathChars = {
+            false, false, false, false, false, false, false, false,     // 0x00 - 0x07
+            false, false, false, false, false, false, false, false,     // 0x08 - 0x0F
+            false, false, false, false, false, false, false, false,     // 0x10 - 0x17
+            false, false, false, false, false, false, false, false,     // 0x18 - 0x1F
+            false, true,  false, false, true,  false, true,  true,      // 0x20 - 0x27
+            true,  true,  true,  true,  true,  true,  true,  true,      // 0x28 - 0x2F
+            true,  true,  true,  true,  true,  true,  true,  true,      // 0x30 - 0x37
+            true,  true,  true,  true,  false, true,  false, false,     // 0x38 - 0x3F
+            true,  true,  true,  true,  true,  true,  true,  true,      // 0x40 - 0x47
+            true,  true,  true,  true,  true,  true,  true,  true,      // 0x48 - 0x4F
+            true,  true,  true,  true,  true,  true,  true,  true,      // 0x50 - 0x57
+            true,  true,  true,  false, false, false, false, true,      // 0x58 - 0x5F
+            false, true,  true,  true,  true,  true,  true,  true,      // 0x60 - 0x67
+            true,  true,  true,  true,  true,  true,  true,  true,      // 0x68 - 0x6F
+            true,  true,  true,  true,  true,  true,  true,  true,      // 0x70 - 0x77
+            true,  true,  true,  false, false, false, true,  false,     // 0x78 - 0x7F
+        };
+
+        public static bool IsValidPathChar(char c)
+        {
+            return c < ValidPathChars.Length && ValidPathChars[c];
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Http.Abstractions.Tests/PathStringTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Abstractions.Tests/PathStringTests.cs
@@ -185,5 +185,21 @@ namespace Microsoft.AspNetCore.Http
 
             Assert.Equal(expectedResult, result);
         }
+
+        [Theory]
+        [InlineData("unreserved", "/abc123.-_~", "/abc123.-_~")]
+        [InlineData("colon", "/:", "/:")]
+        [InlineData("at", "/@", "/@")]
+        [InlineData("sub-delims", "/!$&'()*+,;=", "/!$&'()*+,;=")]
+        [InlineData("reserved", "/?#[]", "/%3F%23%5B%5D")]
+        [InlineData("pct-encoding", "/单行道", "/%E5%8D%95%E8%A1%8C%E9%81%93")]
+        [InlineData("mixed1", "/index/单行道=(x*y)[abc]", "/index/%E5%8D%95%E8%A1%8C%E9%81%93=(x*y)%5Babc%5D")]
+        [InlineData("mixed2", "/index/单行道=(x*y)[abc]_", "/index/%E5%8D%95%E8%A1%8C%E9%81%93=(x*y)%5Babc%5D_")]
+        public void ToUriComponentEscapeCorrectly(string category, string input, string expected)
+        {
+            var path = new PathString(input);
+
+            Assert.Equal(expected, path.ToUriComponent());
+        }
     }
 }


### PR DESCRIPTION
Base on RFC 3986, ensure following characters are not encoded

alpha, digit, "-", "_", ".", "~", "@", ":", "/", "!", "$", ";", "=",
"'", "(", ")", "*", "+", ","

Issue: #660 

/cc @Tratcher 