### PR TITLE
Don't allocate for ResponseCookiesFeature

### DIFF
--- a/samples/SampleApp/PooledHttpContextFactory.cs
+++ b/samples/SampleApp/PooledHttpContextFactory.cs
@@ -12,7 +12,6 @@ namespace SampleApp
 {
     public class PooledHttpContextFactory : IHttpContextFactory
     {
-        private readonly ObjectPool<StringBuilder> _builderPool;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly Stack<PooledHttpContext> _pool = new Stack<PooledHttpContext>();
 
@@ -28,7 +27,6 @@ namespace SampleApp
                 throw new ArgumentNullException(nameof(poolProvider));
             }
 
-            _builderPool = poolProvider.CreateStringBuilderPool();
             _httpContextAccessor = httpContextAccessor;
         }
 
@@ -38,9 +36,6 @@ namespace SampleApp
             {
                 throw new ArgumentNullException(nameof(featureCollection));
             }
-
-            var responseCookiesFeature = new ResponseCookiesFeature(featureCollection, _builderPool);
-            featureCollection.Set<IResponseCookiesFeature>(responseCookiesFeature);
 
             PooledHttpContext httpContext = null;
             lock (_pool)

--- a/src/Microsoft.AspNetCore.Http.Abstractions/project.json
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/project.json
@@ -29,7 +29,8 @@
       "type": "build"
     },
     "NETStandard.Library": "1.6.1-*",
-    "System.Text.Encodings.Web": "4.3.0-*"
+    "System.Text.Encodings.Web": "4.3.0-*",
+    "Microsoft.Extensions.Primitives": "1.1.0-*"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.AspNetCore.Http/Features/ResponseCookiesFeature.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/ResponseCookiesFeature.cs
@@ -16,9 +16,6 @@ namespace Microsoft.AspNetCore.Http.Features
         // Lambda hoisted to static readonly field to improve inlining https://github.com/dotnet/roslyn/issues/13624
         private readonly static Func<IFeatureCollection, IHttpResponseFeature> _nullResponseFeature = f => null;
 
-        // Object pool will be null only in test scenarios e.g. if code news up a DefaultHttpContext.
-        private readonly ObjectPool<StringBuilder> _builderPool;
-
         private FeatureReferences<IHttpResponseFeature> _features;
         private IResponseCookies _cookiesCollection;
 
@@ -50,7 +47,6 @@ namespace Microsoft.AspNetCore.Http.Features
             }
 
             _features = new FeatureReferences<IHttpResponseFeature>(features);
-            _builderPool = builderPool;
         }
 
         private IHttpResponseFeature HttpResponseFeature => _features.Fetch(ref _features.Cache, _nullResponseFeature);
@@ -63,7 +59,7 @@ namespace Microsoft.AspNetCore.Http.Features
                 if (_cookiesCollection == null)
                 {
                     var headers = HttpResponseFeature.Headers;
-                    _cookiesCollection = new ResponseCookies(headers, _builderPool);
+                    _cookiesCollection = new ResponseCookies(headers, null);
                 }
 
                 return _cookiesCollection;

--- a/src/Microsoft.AspNetCore.Http/HttpContextFactory.cs
+++ b/src/Microsoft.AspNetCore.Http/HttpContextFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
@@ -11,7 +10,6 @@ namespace Microsoft.AspNetCore.Http
 {
     public class HttpContextFactory : IHttpContextFactory
     {
-        private readonly ObjectPool<StringBuilder> _builderPool;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly FormOptions _formOptions;
 
@@ -31,7 +29,6 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException(nameof(formOptions));
             }
 
-            _builderPool = poolProvider.CreateStringBuilderPool();
             _formOptions = formOptions.Value;
             _httpContextAccessor = httpContextAccessor;
         }
@@ -42,9 +39,6 @@ namespace Microsoft.AspNetCore.Http
             {
                 throw new ArgumentNullException(nameof(featureCollection));
             }
-
-            var responseCookiesFeature = new ResponseCookiesFeature(featureCollection, _builderPool);
-            featureCollection.Set<IResponseCookiesFeature>(responseCookiesFeature);
 
             var httpContext = new DefaultHttpContext(featureCollection);
             if (_httpContextAccessor != null)

--- a/src/Microsoft.AspNetCore.Http/Internal/ResponseCookies.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/ResponseCookies.cs
@@ -15,8 +15,6 @@ namespace Microsoft.AspNetCore.Http.Internal
     /// </summary>
     public class ResponseCookies : IResponseCookies
     {
-        private readonly ObjectPool<StringBuilder> _builderPool;
-
         /// <summary>
         /// Create a new wrapper.
         /// </summary>
@@ -30,7 +28,6 @@ namespace Microsoft.AspNetCore.Http.Internal
             }
 
             Headers = headers;
-            _builderPool = builderPool;
         }
 
         private IHeaderDictionary Headers { get; set; }
@@ -44,25 +41,7 @@ namespace Microsoft.AspNetCore.Http.Internal
             {
                 Path = "/"
             };
-
-            string cookieValue;
-            if (_builderPool == null)
-            {
-                cookieValue = setCookieHeaderValue.ToString();
-            }
-            else
-            {
-                var stringBuilder = _builderPool.Get();
-                try
-                {
-                    setCookieHeaderValue.AppendToStringBuilder(stringBuilder);
-                    cookieValue = stringBuilder.ToString();
-                }
-                finally
-                {
-                    _builderPool.Return(stringBuilder);
-                }
-            }
+            var cookieValue = setCookieHeaderValue.ToString();
 
             Headers[HeaderNames.SetCookie] = StringValues.Concat(Headers[HeaderNames.SetCookie], cookieValue);
         }
@@ -86,24 +65,7 @@ namespace Microsoft.AspNetCore.Http.Internal
                 HttpOnly = options.HttpOnly,
             };
 
-            string cookieValue;
-            if (_builderPool == null)
-            {
-                cookieValue = setCookieHeaderValue.ToString();
-            }
-            else
-            {
-                var stringBuilder = _builderPool.Get();
-                try
-                {
-                    setCookieHeaderValue.AppendToStringBuilder(stringBuilder);
-                    cookieValue = stringBuilder.ToString();
-                }
-                finally
-                {
-                    _builderPool.Return(stringBuilder);
-                }
-            }
+            var cookieValue = setCookieHeaderValue.ToString();
 
             Headers[HeaderNames.SetCookie] = StringValues.Concat(Headers[HeaderNames.SetCookie], cookieValue);
         }

--- a/src/Microsoft.Net.Http.Headers/SetCookieHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/SetCookieHeaderValue.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Text;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
@@ -89,10 +90,103 @@ namespace Microsoft.Net.Http.Headers
         // name="val ue"; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; httponly
         public override string ToString()
         {
-            StringBuilder header = new StringBuilder();
-            AppendToStringBuilder(header);
+            const string equals = "=";
+            const string separator = "; ";
 
-            return header.ToString();
+            var length = _name.Length + equals.Length + _value.Length;
+
+            string expires = null;
+            string maxAge = null;
+
+            if (Expires.HasValue)
+            {
+                expires = HeaderUtilities.FormatDate(Expires.Value);
+                length += separator.Length + ExpiresToken.Length + equals.Length + expires.Length;
+            }
+
+            if (MaxAge.HasValue)
+            {
+                maxAge = HeaderUtilities.FormatInt64((long)MaxAge.Value.TotalSeconds);
+                length += separator.Length + MaxAgeToken.Length + equals.Length + maxAge.Length;
+            }
+
+            if (Domain != null)
+            {
+                length += separator.Length + DomainToken.Length + equals.Length + Domain.Length;
+            }
+
+            if (Path != null)
+            {
+                length += separator.Length + PathToken.Length + equals.Length + Path.Length;
+            }
+
+            if (Secure)
+            {
+                length += separator.Length + SecureToken.Length;
+            }
+
+            if (HttpOnly)
+            {
+                length += separator.Length + HttpOnlyToken.Length;
+            }
+
+            var sb = new InplaceStringBuilder(length);
+
+            sb.Append(_name);
+            sb.Append(equals);
+            sb.Append(_value);
+
+            if (expires != null)
+            {
+                sb.Append(separator);
+
+                sb.Append(ExpiresToken);
+                sb.Append(equals);
+                sb.Append(expires);
+            }
+
+            if (maxAge != null)
+            {
+                sb.Append(separator);
+
+                sb.Append(MaxAgeToken);
+                sb.Append(equals);
+                sb.Append(maxAge);
+            }
+
+            if (Domain != null)
+            {
+                sb.Append(separator);
+
+                sb.Append(DomainToken);
+                sb.Append(equals);
+                sb.Append(Domain);
+            }
+
+            if (Path != null)
+            {
+                sb.Append(separator);
+
+                sb.Append(PathToken);
+                sb.Append(equals);
+                sb.Append(Path);
+            }
+
+            if (Secure)
+            {
+                sb.Append(separator);
+
+                sb.Append(SecureToken);
+            }
+
+            if (HttpOnly)
+            {
+                sb.Append(separator);
+
+                sb.Append(HttpOnlyToken);
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Http.Tests/ResponseCookiesTest.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/ResponseCookiesTest.cs
@@ -11,27 +11,11 @@ namespace Microsoft.AspNetCore.Http.Tests
 {
     public class ResponseCookiesTest
     {
-        private static readonly ObjectPool<StringBuilder> _builderPool =
-            new DefaultObjectPoolProvider().Create<StringBuilder>(new StringBuilderPooledObjectPolicy());
-
-        public static TheoryData BuilderPoolData
-        {
-            get
-            {
-                return new TheoryData<ObjectPool<StringBuilder>>
-                {
-                    null,
-                    _builderPool,
-                };
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(BuilderPoolData))]
-        public void DeleteCookieShouldSetDefaultPath(ObjectPool<StringBuilder> builderPool)
+        [Fact]
+        public void DeleteCookieShouldSetDefaultPath()
         {
             var headers = new HeaderDictionary();
-            var cookies = new ResponseCookies(headers, builderPool);
+            var cookies = new ResponseCookies(headers, null);
             var testcookie = "TestCookie";
 
             cookies.Delete(testcookie);
@@ -43,12 +27,11 @@ namespace Microsoft.AspNetCore.Http.Tests
             Assert.Contains("expires=Thu, 01 Jan 1970 00:00:00 GMT", cookieHeaderValues[0]);
         }
 
-        [Theory]
-        [MemberData(nameof(BuilderPoolData))]
-        public void NoParamsDeleteRemovesCookieCreatedByAdd(ObjectPool<StringBuilder> builderPool)
+        [Fact]
+        public void NoParamsDeleteRemovesCookieCreatedByAdd()
         {
             var headers = new HeaderDictionary();
-            var cookies = new ResponseCookies(headers, builderPool);
+            var cookies = new ResponseCookies(headers, null);
             var testcookie = "TestCookie";
 
             cookies.Append(testcookie, testcookie);
@@ -66,15 +49,15 @@ namespace Microsoft.AspNetCore.Http.Tests
             get
             {
                 // key, value, object pool, expected
-                return new TheoryData<string, string, ObjectPool<StringBuilder>, string>
+                return new TheoryData<string, string, string>
                 {
-                    { "key", "value", null, "key=value" },
-                    { "key,", "!value", null, "key%2C=%21value" },
-                    { "ke#y,", "val^ue", null, "ke%23y%2C=val%5Eue" },
-                    { "key", "value", _builderPool, "key=value" },
-                    { "key,", "!value", _builderPool, "key%2C=%21value" },
-                    { "ke#y,", "val^ue", _builderPool, "ke%23y%2C=val%5Eue" },
-                    { "base64", "QUI+REU/Rw==", _builderPool, "base64=QUI%2BREU%2FRw%3D%3D" },
+                    { "key", "value", "key=value" },
+                    { "key,", "!value", "key%2C=%21value" },
+                    { "ke#y,", "val^ue", "ke%23y%2C=val%5Eue" },
+                    { "key", "value", "key=value" },
+                    { "key,", "!value", "key%2C=%21value" },
+                    { "ke#y,", "val^ue", "ke%23y%2C=val%5Eue" },
+                    { "base64", "QUI+REU/Rw==", "base64=QUI%2BREU%2FRw%3D%3D" },
                 };
             }
         }
@@ -84,11 +67,10 @@ namespace Microsoft.AspNetCore.Http.Tests
         public void EscapesKeyValuesBeforeSettingCookie(
             string key,
             string value,
-            ObjectPool<StringBuilder> builderPool,
             string expected)
         {
             var headers = new HeaderDictionary();
-            var cookies = new ResponseCookies(headers, builderPool);
+            var cookies = new ResponseCookies(headers, null);
 
             cookies.Append(key, value);
 


### PR DESCRIPTION
* Don't allocate ResponseCookiesFeature when not used
* Don't allocate StringBuilder pool
* Don't allocate StringBuilders
* Don't allocate extra strings when constructing cookie string

Resolves #676

/cc @davidfowl @muratg @Tratcher @pakrym 