### PR TITLE
Make HttpContextAccessor static AsyncLocal

### DIFF
--- a/src/Microsoft.AspNetCore.Http/HttpContextAccessor.cs
+++ b/src/Microsoft.AspNetCore.Http/HttpContextAccessor.cs
@@ -30,7 +30,8 @@ namespace Microsoft.AspNetCore.Http
         }
 
 #elif NETSTANDARD1_3
-        private AsyncLocal<HttpContext> _httpContextCurrent = new AsyncLocal<HttpContext>();
+        private static AsyncLocal<HttpContext> _httpContextCurrent = new AsyncLocal<HttpContext>();
+
         public HttpContext HttpContext
         {
             get


### PR DESCRIPTION
#723 The .NET 4.5.1 version is static but the .NETStandard1.3 version isn't, which can cause problems if you end up with different instances of HttpContextAccessor.