### PR TITLE
[Perf] Add ContentLength to IHeaderDictionary

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Features/IHeaderDictionary.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/IHeaderDictionary.cs
@@ -17,5 +17,10 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="key"></param>
         /// <returns>The stored value, or StringValues.Empty if the key is not present.</returns>
         new StringValues this[string key] { get; set; }
+
+        /// <summary>
+        /// Strongly typed access to the Content-Length header. Implementations must keep this in sync with the string representation.
+        /// </summary>
+        long? ContentLength { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Http.Features/exceptions.net45.json
+++ b/src/Microsoft.AspNetCore.Http.Features/exceptions.net45.json
@@ -1,0 +1,14 @@
+[
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Http.IHeaderDictionary : System.Collections.Generic.IDictionary<System.String, Microsoft.Extensions.Primitives.StringValues>",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Http.IHeaderDictionary : System.Collections.Generic.IDictionary<System.String, Microsoft.Extensions.Primitives.StringValues>",
+    "NewMemberId": "System.Nullable<System.Int64> get_ContentLength()",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Http.IHeaderDictionary : System.Collections.Generic.IDictionary<System.String, Microsoft.Extensions.Primitives.StringValues>",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Http.IHeaderDictionary : System.Collections.Generic.IDictionary<System.String, Microsoft.Extensions.Primitives.StringValues>",
+    "NewMemberId": "System.Void set_ContentLength(System.Nullable<System.Int64> value)",
+    "Kind": "Addition"
+  }
+]

--- a/src/Microsoft.AspNetCore.Http.Features/exceptions.netcore.json
+++ b/src/Microsoft.AspNetCore.Http.Features/exceptions.netcore.json
@@ -1,0 +1,14 @@
+[
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Http.IHeaderDictionary : System.Collections.Generic.IDictionary<System.String, Microsoft.Extensions.Primitives.StringValues>",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Http.IHeaderDictionary : System.Collections.Generic.IDictionary<System.String, Microsoft.Extensions.Primitives.StringValues>",
+    "NewMemberId": "System.Nullable<System.Int64> get_ContentLength()",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Http.IHeaderDictionary : System.Collections.Generic.IDictionary<System.String, Microsoft.Extensions.Primitives.StringValues>",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Http.IHeaderDictionary : System.Collections.Generic.IDictionary<System.String, Microsoft.Extensions.Primitives.StringValues>",
+    "NewMemberId": "System.Void set_ContentLength(System.Nullable<System.Int64> value)",
+    "Kind": "Addition"
+  }
+]

--- a/src/Microsoft.AspNetCore.Http/HeaderDictionary.cs
+++ b/src/Microsoft.AspNetCore.Http/HeaderDictionary.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Http
 {
@@ -95,6 +96,34 @@ namespace Microsoft.AspNetCore.Http
         {
             get { return Store[key]; }
             set { this[key] = value; }
+        }
+
+        public long? ContentLength
+        {
+            get
+            {
+                long value;
+                var rawValue = this[HeaderNames.ContentLength];
+                if (rawValue.Count == 1 &&
+                    !string.IsNullOrWhiteSpace(rawValue[0]) &&
+                    HeaderUtilities.TryParseInt64(new StringSegment(rawValue[0]).Trim(), out value))
+                {
+                    return value;
+                }
+
+                return null;
+            }
+            set
+            {
+                if (value.HasValue)
+                {
+                    this[HeaderNames.ContentLength] = HeaderUtilities.FormatInt64(value.Value);
+                }
+                else
+                {
+                    this.Remove(HeaderNames.ContentLength);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpRequest.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpRequest.cs
@@ -72,14 +72,8 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public override long? ContentLength
         {
-            get
-            {
-                return ParsingHelpers.GetContentLength(Headers);
-            }
-            set
-            {
-                ParsingHelpers.SetContentLength(Headers, value);
-            }
+            get { return Headers.ContentLength; }
+            set { Headers.ContentLength = value; }
         }
 
         public override Stream Body

--- a/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpResponse.cs
@@ -63,14 +63,8 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public override long? ContentLength
         {
-            get
-            {
-                return ParsingHelpers.GetContentLength(Headers);
-            }
-            set
-            {
-                ParsingHelpers.SetContentLength(Headers, value);
-            }
+            get { return Headers.ContentLength; }
+            set { Headers.ContentLength = value; }
         }
 
         public override string ContentType

--- a/src/Microsoft.AspNetCore.Http/Internal/ParsingHelpers.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/ParsingHelpers.cs
@@ -403,41 +403,5 @@ namespace Microsoft.AspNetCore.Http.Internal
 
             return value;
         }
-
-        public static long? GetContentLength(IHeaderDictionary headers)
-        {
-            if (headers == null)
-            {
-                throw new ArgumentNullException(nameof(headers));
-            }
-
-            long value;
-            var rawValue = headers[HeaderNames.ContentLength];
-            if (rawValue.Count == 1 &&
-                !string.IsNullOrWhiteSpace(rawValue[0]) &&
-                HeaderUtilities.TryParseInt64(new StringSegment(rawValue[0]).Trim(), out value))
-            {
-                return value;
-            }
-
-            return null;
-        }
-
-        public static void SetContentLength(IHeaderDictionary headers, long? value)
-        {
-            if (headers == null)
-            {
-                throw new ArgumentNullException(nameof(headers));
-            }
-
-            if (value.HasValue)
-            {
-                headers[HeaderNames.ContentLength] = HeaderUtilities.FormatInt64(value.Value);
-            }
-            else
-            {
-                headers.Remove(HeaderNames.ContentLength);
-            }
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.Owin/DictionaryStringValuesWrapper.cs
+++ b/src/Microsoft.AspNetCore.Owin/DictionaryStringValuesWrapper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Owin
 {
@@ -40,6 +41,40 @@ namespace Microsoft.AspNetCore.Owin
         {
             get { return Inner[key]; }
             set { Inner[key] = value; }
+        }
+
+        public long? ContentLength
+        {
+            get
+            {
+                long value;
+
+                string[] rawValue;
+                if (!Inner.TryGetValue(HeaderNames.ContentLength, out rawValue))
+                {
+                    return null;
+                }
+
+                if (rawValue.Length == 1 &&
+                    !string.IsNullOrWhiteSpace(rawValue[0]) &&
+                    HeaderUtilities.TryParseInt64(new StringSegment(rawValue[0]).Trim(), out value))
+                {
+                    return value;
+                }
+
+                return null;
+            }
+            set
+            {
+                if (value.HasValue)
+                {
+                    Inner[HeaderNames.ContentLength] = (StringValues)HeaderUtilities.FormatInt64(value.Value);
+                }
+                else
+                {
+                    Inner.Remove(HeaderNames.ContentLength);
+                }
+            }
         }
 
         int ICollection<KeyValuePair<string, StringValues>>.Count => Inner.Count;


### PR DESCRIPTION
#407 Headers are stored as strings, but multiple components may need to examine the Content-Length header value on a request or response. To avoid redundant conversions allow both representations to be stored. The IHeaderDictionary implementations are responsible for keeping the representations in sync. I did not attempt any optimizations in the default implementations, they are primarily used for testing. The real gains will come from the WebListener and Kestrel implementations.

Do not merge this until the WebListener, Kestrel, and Hosting implementations are ready.

@benaadams Does this give you enough of an abstraction to implement in Kestrel? Do you want to take the first stab at it? The current xproj vs csproj schism may complicate matters.