### PR TITLE
Added support for middleware activation via IMiddlewareFactory

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/UseMiddlewareExtensions.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/UseMiddlewareExtensions.cs
@@ -42,6 +42,18 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
         public static IApplicationBuilder UseMiddleware(this IApplicationBuilder app, Type middleware, params object[] args)
         {
+            if (typeof(IMiddleware).GetTypeInfo().IsAssignableFrom(middleware.GetTypeInfo()))
+            {
+                // IMiddleware doesn't support passing args directly since it's 
+                // activated from the container
+                if (args.Length > 0)
+                {
+                    throw new NotSupportedException(Resources.FormatException_UseMiddlewareExplicitArgumentsNotSupported(typeof(IMiddleware)));
+                }
+
+                return UseMiddlewareInterface(app, middleware);
+            }
+
             var applicationServices = app.ApplicationServices;
             return app.Use(next =>
             {
@@ -89,6 +101,41 @@ namespace Microsoft.AspNetCore.Builder
                     }
 
                     return factory(instance, context, serviceProvider);
+                };
+            });
+        }
+
+        private static IApplicationBuilder UseMiddlewareInterface(IApplicationBuilder app, Type middlewareType)
+        {
+            return app.Use(next =>
+            {
+                return async context =>
+                {
+                    var middlewareFactory = (IMiddlewareFactory)context.RequestServices.GetService(typeof(IMiddlewareFactory));
+
+                    if (middlewareFactory == null)
+                    {
+                        // No middleware factory
+                        throw new InvalidOperationException(Resources.FormatException_UseMiddlewareNoMiddlewareFactory(typeof(IMiddlewareFactory)));
+                    }
+
+                    var middleware = middlewareFactory.Create(middlewareType);
+
+                    if (middleware == null)
+                    {
+                        // The factory returned null, it's a broken implementation
+                        throw new InvalidOperationException(Resources.FormatException_UseMiddlewareUnableToCreateMiddleware(middlewareType));
+
+                    }
+
+                    try
+                    {
+                        await middleware.Invoke(context, next);
+                    }
+                    finally
+                    {
+                        middlewareFactory.Release(middleware);
+                    }
                 };
             });
         }

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/UseMiddlewareExtensions.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/UseMiddlewareExtensions.cs
@@ -112,7 +112,6 @@ namespace Microsoft.AspNetCore.Builder
                 return async context =>
                 {
                     var middlewareFactory = (IMiddlewareFactory)context.RequestServices.GetService(typeof(IMiddlewareFactory));
-
                     if (middlewareFactory == null)
                     {
                         // No middleware factory
@@ -120,12 +119,10 @@ namespace Microsoft.AspNetCore.Builder
                     }
 
                     var middleware = middlewareFactory.Create(middlewareType);
-
                     if (middleware == null)
                     {
                         // The factory returned null, it's a broken implementation
                         throw new InvalidOperationException(Resources.FormatException_UseMiddlewareUnableToCreateMiddleware(middlewareType));
-
                     }
 
                     try

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/UseMiddlewareExtensions.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/UseMiddlewareExtensions.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Builder
                     if (middleware == null)
                     {
                         // The factory returned null, it's a broken implementation
-                        throw new InvalidOperationException(Resources.FormatException_UseMiddlewareUnableToCreateMiddleware(middlewareType));
+                        throw new InvalidOperationException(Resources.FormatException_UseMiddlewareUnableToCreateMiddleware(middlewareFactory.GetType(), middlewareType));
                     }
 
                     try

--- a/src/Microsoft.AspNetCore.Http.Abstractions/IMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/IMiddleware.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Microsoft.AspNetCore.Http.Abstractions/IMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/IMiddleware.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Http
+{
+    /// <summary>
+    /// Defines middleware that can be added to the application's request pipeline.
+    /// </summary>
+    public interface IMiddleware
+    {
+        /// <summary>
+        /// Request handling method.
+        /// </summary>
+        /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
+        /// <param name="next">The delegate representing the remaining middleware in the request pipeline.</param>
+        /// <returns>A <see cref="Task"/> that represents the execution of this middleware.</returns>
+        Task Invoke(HttpContext context, RequestDelegate next);
+    }
+}

--- a/src/Microsoft.AspNetCore.Http.Abstractions/IMiddlewareFactory.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/IMiddlewareFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Microsoft.AspNetCore.Http.Abstractions/IMiddlewareFactory.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/IMiddlewareFactory.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Http
+{
+    /// <summary>
+    /// Provides methods to create middlware.
+    /// </summary>
+    public interface IMiddlewareFactory
+    {
+        /// <summary>
+        /// Creates a middleware instance for each request.
+        /// </summary>
+        /// <param name="middlewareType">The concrete <see cref="Type"/> of the <see cref="IMiddleware"/>.</param>
+        /// <returns>The <see cref="IMiddleware"/> instance.</returns>
+        IMiddleware Create(Type middlewareType);
+
+        /// <summary>
+        /// Releases a <see cref="IMiddleware"/> instance at the end of each request.
+        /// </summary>
+        /// <param name="middleware">The <see cref="IMiddleware"/> instance to release.</param>
+        void Release(IMiddleware middleware);
+    }
+}

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Properties/Resources.Designer.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Http.Abstractions
         }
 
         /// <summary>
-        /// Unable to create middleware '{0}'.
+        /// '{0}' failed to create middleware of type '{1}'.
         /// </summary>
         internal static string Exception_UseMiddlewareUnableToCreateMiddleware
         {
@@ -179,11 +179,11 @@ namespace Microsoft.AspNetCore.Http.Abstractions
         }
 
         /// <summary>
-        /// Unable to create middleware '{0}'.
+        /// '{0}' failed to create middleware of type '{1}'.
         /// </summary>
-        internal static string FormatException_UseMiddlewareUnableToCreateMiddleware(object p0)
+        internal static string FormatException_UseMiddlewareUnableToCreateMiddleware(object p0, object p1)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Exception_UseMiddlewareUnableToCreateMiddleware"), p0);
+            return string.Format(CultureInfo.CurrentCulture, GetString("Exception_UseMiddlewareUnableToCreateMiddleware"), p0, p1);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Properties/Resources.Designer.cs
@@ -154,6 +154,54 @@ namespace Microsoft.AspNetCore.Http.Abstractions
             return GetString("Exception_PortMustBeGreaterThanZero");
         }
 
+        /// <summary>
+        /// No service for type '{0}' has been registered.
+        /// </summary>
+        internal static string Exception_UseMiddlewareNoMiddlewareFactory
+        {
+            get { return GetString("Exception_UseMiddlewareNoMiddlewareFactory"); }
+        }
+
+        /// <summary>
+        /// No service for type '{0}' has been registered.
+        /// </summary>
+        internal static string FormatException_UseMiddlewareNoMiddlewareFactory(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Exception_UseMiddlewareNoMiddlewareFactory"), p0);
+        }
+
+        /// <summary>
+        /// Unable to create middleware '{0}'.
+        /// </summary>
+        internal static string Exception_UseMiddlewareUnableToCreateMiddleware
+        {
+            get { return GetString("Exception_UseMiddlewareUnableToCreateMiddleware"); }
+        }
+
+        /// <summary>
+        /// Unable to create middleware '{0}'.
+        /// </summary>
+        internal static string FormatException_UseMiddlewareUnableToCreateMiddleware(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Exception_UseMiddlewareUnableToCreateMiddleware"), p0);
+        }
+
+        /// <summary>
+        /// Types that implement '{0}' do not support explicit arguments.
+        /// </summary>
+        internal static string Exception_UseMiddlewareExplicitArgumentsNotSupported
+        {
+            get { return GetString("Exception_UseMiddlewareExplicitArgumentsNotSupported"); }
+        }
+
+        /// <summary>
+        /// Types that implement '{0}' do not support explicit arguments.
+        /// </summary>
+        internal static string FormatException_UseMiddlewareExplicitArgumentsNotSupported(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Exception_UseMiddlewareExplicitArgumentsNotSupported"), p0);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Resources.resx
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Resources.resx
@@ -148,7 +148,7 @@
     <value>No service for type '{0}' has been registered.</value>
   </data>
   <data name="Exception_UseMiddlewareUnableToCreateMiddleware" xml:space="preserve">
-    <value>Unable to create middleware '{0}'.</value>
+    <value>'{0}' failed to create middleware of type '{1}'.</value>
   </data>
   <data name="Exception_UseMiddlewareExplicitArgumentsNotSupported" xml:space="preserve">
     <value>Types that implement '{0}' do not support explicit arguments.</value>

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Resources.resx
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Resources.resx
@@ -144,4 +144,13 @@
   <data name="Exception_PortMustBeGreaterThanZero" xml:space="preserve">
     <value>The value must be greater than zero.</value>
   </data>
+  <data name="Exception_UseMiddlewareNoMiddlewareFactory" xml:space="preserve">
+    <value>No service for type '{0}' has been registered.</value>
+  </data>
+  <data name="Exception_UseMiddlewareUnableToCreateMiddleware" xml:space="preserve">
+    <value>Unable to create middleware '{0}'.</value>
+  </data>
+  <data name="Exception_UseMiddlewareExplicitArgumentsNotSupported" xml:space="preserve">
+    <value>Types that implement '{0}' do not support explicit arguments.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Http/MiddlewareFactory.cs
+++ b/src/Microsoft.AspNetCore.Http/MiddlewareFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Microsoft.AspNetCore.Http/MiddlewareFactory.cs
+++ b/src/Microsoft.AspNetCore.Http/MiddlewareFactory.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public class MiddlewareFactory : IMiddlewareFactory
+    {
+        // The default middleware factory is just an IServiceProvider proxy.
+        // This should be registered as a scoped service so that the middleware instances
+        // don't end up being singletons.
+        private readonly IServiceProvider _serviceProvider;
+
+        public MiddlewareFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public IMiddleware Create(Type middlewareType)
+        {
+            return _serviceProvider.GetRequiredService(middlewareType) as IMiddleware;
+        }
+
+        public void Release(IMiddleware middleware)
+        {
+            // The container owns the lifetime of the service
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Http.Abstractions.Tests/UseMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Http.Abstractions.Tests/UseMiddlewareTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Builder.Internal;
@@ -83,13 +84,129 @@ namespace Microsoft.AspNetCore.Http
             var exception = Assert.Throws<NotSupportedException>(() => builder.Build());
         }
 
+        [Fact]
+        public void UseMiddlewareWithIMiddlewareThrowsIfParametersSpecified()
+        {
+            var mockServiceProvider = new DummyServiceProvider();
+            var builder = new ApplicationBuilder(mockServiceProvider);
+            var exception = Assert.Throws<NotSupportedException>(() => builder.UseMiddleware(typeof(Middleware), "arg"));
+            Assert.Equal(Resources.FormatException_UseMiddlewareExplicitArgumentsNotSupported(typeof(IMiddleware)), exception.Message);
+        }
+
+        [Fact]
+        public async Task UseMiddlewareWithIMiddlewareThrowsIfNoIMiddlewareFactoryRegistered()
+        {
+            var mockServiceProvider = new DummyServiceProvider();
+            var builder = new ApplicationBuilder(mockServiceProvider);
+            builder.UseMiddleware(typeof(Middleware));
+            var app = builder.Build();
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                var context = new DefaultHttpContext();
+                var sp = new DummyServiceProvider();
+                context.RequestServices = sp;
+                await app(context);
+            });
+            Assert.Equal(Resources.FormatException_UseMiddlewareNoMiddlewareFactory(typeof(IMiddlewareFactory)), exception.Message);
+        }
+
+        [Fact]
+        public async Task UseMiddlewareWithIMiddlewareThrowsIfMiddlewareFactoryCreateReturnsNull()
+        {
+            var mockServiceProvider = new DummyServiceProvider();
+            var builder = new ApplicationBuilder(mockServiceProvider);
+            builder.UseMiddleware(typeof(Middleware));
+            var app = builder.Build();
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                var context = new DefaultHttpContext();
+                var sp = new DummyServiceProvider();
+                sp.AddService(typeof(IMiddlewareFactory), new BadMiddlewareFactory());
+                context.RequestServices = sp;
+                await app(context);
+            });
+
+            Assert.Equal(Resources.FormatException_UseMiddlewareUnableToCreateMiddleware(typeof(Middleware)), exception.Message);
+        }
+
+        [Fact]
+        public async Task UseMiddlewareWithIMiddlewareWorks()
+        {
+            var mockServiceProvider = new DummyServiceProvider();
+            var builder = new ApplicationBuilder(mockServiceProvider);
+            builder.UseMiddleware(typeof(Middleware));
+            var app = builder.Build();
+            var context = new DefaultHttpContext();
+            var sp = new DummyServiceProvider();
+            var middlewareFactory = new BasicMiddlewareFactory();
+            sp.AddService(typeof(IMiddlewareFactory), middlewareFactory);
+            context.RequestServices = sp;
+            await app(context);
+            Assert.Equal(true, context.Items["before"]);
+            Assert.Equal(true, context.Items["after"]);
+            Assert.NotNull(middlewareFactory.Created);
+            Assert.NotNull(middlewareFactory.Released);
+            Assert.IsType(typeof(Middleware), middlewareFactory.Created);
+            Assert.IsType(typeof(Middleware), middlewareFactory.Released);
+            Assert.Same(middlewareFactory.Created, middlewareFactory.Released);
+        }
+
+        public class Middleware : IMiddleware
+        {
+            public async Task Invoke(HttpContext context, RequestDelegate next)
+            {
+                context.Items["before"] = true;
+                await next(context);
+                context.Items["after"] = true;
+            }
+        }
+
+        public class BasicMiddlewareFactory : IMiddlewareFactory
+        {
+            public IMiddleware Created { get; private set; }
+            public IMiddleware Released { get; private set; }
+
+            public IMiddleware Create(Type middlewareType)
+            {
+                Created = Activator.CreateInstance(middlewareType) as IMiddleware;
+                return Created;
+            }
+
+            public void Release(IMiddleware middleware)
+            {
+                Released = middleware;
+            }
+        }
+
+        public class BadMiddlewareFactory : IMiddlewareFactory
+        {
+            public IMiddleware Create(Type middlewareType)
+            {
+                return null;
+            }
+
+            public void Release(IMiddleware middleware)
+            {
+
+            }
+        }
+
         private class DummyServiceProvider : IServiceProvider
         {
+            private Dictionary<Type, object> _services = new Dictionary<Type, object>();
+
+            public void AddService(Type type, object value) => _services[type] = value;
+
             public object GetService(Type serviceType)
             {
                 if (serviceType == typeof(IServiceProvider))
                 {
                     return this;
+                }
+
+                if (_services.TryGetValue(serviceType, out object value))
+                {
+                    return value;
                 }
                 return null;
             }

--- a/test/Microsoft.AspNetCore.Http.Abstractions.Tests/UseMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Http.Abstractions.Tests/UseMiddlewareTest.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Http
                 await app(context);
             });
 
-            Assert.Equal(Resources.FormatException_UseMiddlewareUnableToCreateMiddleware(typeof(Middleware)), exception.Message);
+            Assert.Equal(Resources.FormatException_UseMiddlewareUnableToCreateMiddleware(typeof(BadMiddlewareFactory), typeof(Middleware)), exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
- Fixes #754 
- IMiddlewareFactory and IMiddleware are new extensiblity points for
activating and authoring middleware. Under the covers, middleware is still
very much just a function. This just provides a nice way to get a per request
activated middleware instance that is created and released via the IMiddlewareFactory (this critical for non conforming containers, see https://github.com/dotnetjunkie/Missing-Core-DI-Extensions/blob/7efd3c3f1aa6330d303d0a3e2d28fdc43687b9f4/src/SampleApplication.SimpleInjector/Startup.cs#L52-L55 for more details).
The caveats are that middleware needs to be registered in the container (by default)
and that not possible to explicitly pass arguments directly via UseMiddleware.
- Added tests

/cc @Tratcher @halter73 @pakrym 