### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.AspNetCore.Http.Abstractions.Tests/Microsoft.AspNetCore.Http.Abstractions.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Http.Abstractions.Tests/Microsoft.AspNetCore.Http.Abstractions.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Http\Microsoft.AspNetCore.Http.csproj" />

--- a/test/Microsoft.AspNetCore.Http.Extensions.Tests/Microsoft.AspNetCore.Http.Extensions.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Http.Extensions.Tests/Microsoft.AspNetCore.Http.Extensions.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Http\Microsoft.AspNetCore.Http.csproj" />

--- a/test/Microsoft.AspNetCore.Http.Features.Tests/Microsoft.AspNetCore.Http.Features.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Http.Features.Tests/Microsoft.AspNetCore.Http.Features.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Http.Features\Microsoft.AspNetCore.Http.Features.csproj" />

--- a/test/Microsoft.AspNetCore.Http.Tests/HttpContextFactoryTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/HttpContextFactoryTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Http
             contextFactory.Dispose(context);
         }
 
-#if NET451
+#if NET452
         private static void DomainFunc()
         {
             var accessor = new HttpContextAccessor();

--- a/test/Microsoft.AspNetCore.Http.Tests/Microsoft.AspNetCore.Http.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Http.Tests/Microsoft.AspNetCore.Http.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Http\Microsoft.AspNetCore.Http.csproj" />

--- a/test/Microsoft.AspNetCore.Owin.Tests/Microsoft.AspNetCore.Owin.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Owin.Tests/Microsoft.AspNetCore.Owin.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Http\Microsoft.AspNetCore.Http.csproj" />

--- a/test/Microsoft.AspNetCore.WebUtilities.Tests/FileBufferingReadStreamTests.cs
+++ b/test/Microsoft.AspNetCore.WebUtilities.Tests/FileBufferingReadStreamTests.cs
@@ -293,7 +293,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         private static string GetCurrentDirectory()
         {
-#if NET451
+#if NET452
             return AppDomain.CurrentDomain.BaseDirectory;
 #else
             return AppContext.BaseDirectory;

--- a/test/Microsoft.AspNetCore.WebUtilities.Tests/HttpResponseStreamWriterTest.cs
+++ b/test/Microsoft.AspNetCore.WebUtilities.Tests/HttpResponseStreamWriterTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.WebUtilities.Test
             Assert.Equal(expectedData, memoryStream.ToArray());
         }
 
-#if NET451
+#if NET452
         [Fact]
         public async Task DoesNotFlush_UnderlyingStream_OnClosingWriter()
         {
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.WebUtilities.Test
             Assert.Equal(0, stream.FlushAsyncCallCount);
         }
 
-#if NET451
+#if NET452
         [Fact]
         public async Task DoesNotClose_UnderlyingStream_OnDisposingWriter()
         {
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.WebUtilities.Test
             await writer.WriteAsync(new string('a', byteLength));
 
             // Act
-#if NET451
+#if NET452
             writer.Close();
 #else
             writer.Dispose();
@@ -502,7 +502,7 @@ namespace Microsoft.AspNetCore.WebUtilities.Test
                 return base.WriteAsync(buffer, offset, count, cancellationToken);
             }
 
-#if NET451
+#if NET452
             public override void Close()
             {
                 CloseCallCount++;

--- a/test/Microsoft.AspNetCore.WebUtilities.Tests/Microsoft.AspNetCore.WebUtilities.Tests.csproj
+++ b/test/Microsoft.AspNetCore.WebUtilities.Tests/Microsoft.AspNetCore.WebUtilities.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.WebUtilities\Microsoft.AspNetCore.WebUtilities.csproj" />

--- a/test/Microsoft.Net.Http.Headers.Tests/Microsoft.Net.Http.Headers.Tests.csproj
+++ b/test/Microsoft.Net.Http.Headers.Tests/Microsoft.Net.Http.Headers.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Net.Http.Headers\Microsoft.Net.Http.Headers.csproj" />


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows