### PR TITLE
Add Owin extension for convenience

### DIFF
--- a/src/Microsoft.AspNetCore.Owin/OwinExtensions.cs
+++ b/src/Microsoft.AspNetCore.Owin/OwinExtensions.cs
@@ -84,6 +84,16 @@ namespace Microsoft.AspNetCore.Builder
 
         public static IApplicationBuilder UseOwin(this IApplicationBuilder builder, Action<AddMiddleware> pipeline)
         {
+            return UseOwinHelp(builder, pipeline, b => b.UseOwin());
+        }
+
+        public static IApplicationBuilder UseOwinEx(this IApplicationBuilder builder, Action<AddMiddlewareEx> pipeline)
+        {
+            return UseOwinHelp(builder, pipeline, b => b.UseOwinEx());
+        }
+
+        private static IApplicationBuilder UseOwinHelp<T>(this IApplicationBuilder builder, Action<T> pipeline, Func<IApplicationBuilder, T> useOwin)
+        {
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
@@ -93,7 +103,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(pipeline));
             }
 
-            pipeline(builder.UseOwin());
+            pipeline(useOwin(builder));
             return builder;
         }
 

--- a/src/Microsoft.AspNetCore.Owin/OwinExtensions.cs
+++ b/src/Microsoft.AspNetCore.Owin/OwinExtensions.cs
@@ -66,18 +66,10 @@ namespace Microsoft.AspNetCore.Builder
 
             AddMiddlewareEx add = middleware =>
             {
-                Func<RequestDelegate, RequestDelegate> middleware1 = next1 =>
+                Func<HttpContext, Func<Task>, Task> middleware1 = (httpContext, next1) =>
                 {
-                    return httpContext =>
-                    {
-                        var env = GetOrNewEnvironment(httpContext);
-                        Func<Task> next = () =>
-                        {
-                            return next1((HttpContext)env[typeof(HttpContext).FullName]);
-                        };
-
-                        return middleware(env, next);
-                    };
+                    var env = GetOrNewEnvironment(httpContext);
+                    return middleware(env, next1);
                 };
                 builder.Use(middleware1);
             };
@@ -87,7 +79,6 @@ namespace Microsoft.AspNetCore.Builder
                 AppFunc nextApp = _ => next();
                 return (WebSocketAcceptAdapter.AdaptWebSockets(nextApp))(env);
             });
-
             return add;
         }
 

--- a/test/Microsoft.AspNetCore.Owin.Tests/OwinExtensionTests.cs
+++ b/test/Microsoft.AspNetCore.Owin.Tests/OwinExtensionTests.cs
@@ -4,13 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using System.Net.WebSockets;
 
 namespace Microsoft.AspNetCore.Owin
 {

--- a/test/Microsoft.AspNetCore.Owin.Tests/OwinExtensionTests.cs
+++ b/test/Microsoft.AspNetCore.Owin.Tests/OwinExtensionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.WebSockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Builder.Internal;
@@ -14,11 +15,10 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Owin
 {
-    using System.Threading;
     using AddMiddleware = Action<Func<
-Func<IDictionary<string, object>, Task>,
-Func<IDictionary<string, object>, Task>
->>;
+          Func<IDictionary<string, object>, Task>,
+          Func<IDictionary<string, object>, Task>
+        >>;
     using AppFunc = Func<IDictionary<string, object>, Task>;
     using CreateMiddleware = Func<
           Func<IDictionary<string, object>, Task>,


### PR DESCRIPTION
`IApplicationBuilder` has a very convenient extension that we can add a middleware like
```C#
app.Use((context, next) =>
{
    // do something
    return next();
});
```
rather than
```C#
app.Use(next =>
{
    return context =>
    {
        // do something
        return next(context);
    }
});
```
The former one is much more straightforward and easier to understand and to use.

Asp.Net Owin (Project [Katana](https://github.com/aspnet/AspNetKatana/blob/dev/src/Microsoft.Owin/Extensions/AppBuilderUseExtensions.cs)) also has a similar extension, but Asp.Net Core Owin doesn't. Therefore, I propose to add a similar extension to Asp.Net Core Owin so that we can align them and write code easier like:
```C#
app.UseOwinEx(addToPipeline =>
{
    addToPipeline((env, next) =>
    {
        // do something
        return next();
    });
});
```

Here is the pull request including test case.