### PR TITLE
Obsolete Auth 1.0

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticateInfo.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticateInfo.cs
@@ -9,21 +9,25 @@ namespace Microsoft.AspNetCore.Http.Authentication
     /// <summary>
     /// Used to store the results of an Authenticate call.
     /// </summary>
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class AuthenticateInfo
     {
         /// <summary>
         /// The <see cref="ClaimsPrincipal"/>.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public ClaimsPrincipal Principal { get; set; }
 
         /// <summary>
         /// The <see cref="AuthenticationProperties"/>.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public AuthenticationProperties Properties { get; set; }
 
         /// <summary>
         /// The <see cref="AuthenticationDescription"/>.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public AuthenticationDescription Description { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticationDescription.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticationDescription.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
     /// <summary>
     /// Contains information describing an authentication provider.
     /// </summary>
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class AuthenticationDescription
     {
         private const string DisplayNamePropertyKey = "DisplayName";

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticationManager.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticationManager.cs
@@ -9,37 +9,47 @@ using Microsoft.AspNetCore.Http.Features.Authentication;
 
 namespace Microsoft.AspNetCore.Http.Authentication
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public abstract class AuthenticationManager
     {
         /// <summary>
         /// Constant used to represent the automatic scheme
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public const string AutomaticScheme = "Automatic";
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public abstract HttpContext HttpContext { get; }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public abstract IEnumerable<AuthenticationDescription> GetAuthenticationSchemes();
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public abstract Task<AuthenticateInfo> GetAuthenticateInfoAsync(string authenticationScheme);
 
         // Will remove once callees have been updated
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public abstract Task AuthenticateAsync(AuthenticateContext context);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual async Task<ClaimsPrincipal> AuthenticateAsync(string authenticationScheme)
         {
             return (await GetAuthenticateInfoAsync(authenticationScheme))?.Principal;
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task ChallengeAsync()
         {
             return ChallengeAsync(properties: null);
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task ChallengeAsync(AuthenticationProperties properties)
         {
             return ChallengeAsync(authenticationScheme: AutomaticScheme, properties: properties);
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task ChallengeAsync(string authenticationScheme)
         {
             if (string.IsNullOrEmpty(authenticationScheme))
@@ -51,6 +61,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
         }
 
         // Leave it up to authentication handler to do the right thing for the challenge
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task ChallengeAsync(string authenticationScheme, AuthenticationProperties properties)
         {
             if (string.IsNullOrEmpty(authenticationScheme))
@@ -61,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
             return ChallengeAsync(authenticationScheme, properties, ChallengeBehavior.Automatic);
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task SignInAsync(string authenticationScheme, ClaimsPrincipal principal)
         {
             if (string.IsNullOrEmpty(authenticationScheme))
@@ -80,9 +92,11 @@ namespace Microsoft.AspNetCore.Http.Authentication
         /// Creates a challenge for the authentication manager with <see cref="ChallengeBehavior.Forbidden"/>.
         /// </summary>
         /// <returns>A <see cref="Task"/> that represents the asynchronous challenge operation.</returns>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task ForbidAsync()
             => ForbidAsync(AutomaticScheme, properties: null);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task ForbidAsync(string authenticationScheme)
         {
             if (authenticationScheme == null)
@@ -94,6 +108,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
         }
 
         // Deny access (typically a 403)
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task ForbidAsync(string authenticationScheme, AuthenticationProperties properties)
         {
             if (authenticationScheme == null)
@@ -109,13 +124,17 @@ namespace Microsoft.AspNetCore.Http.Authentication
         /// </summary>
         /// <param name="properties">Additional arbitrary values which may be used by particular authentication types.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous challenge operation.</returns>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task ForbidAsync(AuthenticationProperties properties)
             => ForbidAsync(AutomaticScheme, properties);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public abstract Task ChallengeAsync(string authenticationScheme, AuthenticationProperties properties, ChallengeBehavior behavior);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public abstract Task SignInAsync(string authenticationScheme, ClaimsPrincipal principal, AuthenticationProperties properties);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public virtual Task SignOutAsync(string authenticationScheme)
         {
             if (authenticationScheme == null)
@@ -126,6 +145,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
             return SignOutAsync(authenticationScheme, properties: null);
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public abstract Task SignOutAsync(string authenticationScheme, AuthenticationProperties properties);
     }
 }

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticationProperties.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Authentication/AuthenticationProperties.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
     /// <summary>
     /// Dictionary used to store state values about the authentication session.
     /// </summary>
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class AuthenticationProperties
     {
         internal const string IssuedUtcKey = ".issued";
@@ -39,11 +40,13 @@ namespace Microsoft.AspNetCore.Http.Authentication
         /// <summary>
         /// State values about the authentication session.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public IDictionary<string, string> Items { get; }
 
         /// <summary>
         /// Gets or sets whether the authentication session is persisted across multiple requests.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public bool IsPersistent
         {
             get { return Items.ContainsKey(IsPersistentKey); }
@@ -69,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
         /// <summary>
         /// Gets or sets the full path or absolute URI to be used as an http redirect response value.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public string RedirectUri
         {
             get
@@ -95,6 +99,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
         /// <summary>
         /// Gets or sets the time at which the authentication ticket was issued.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public DateTimeOffset? IssuedUtc
         {
             get
@@ -129,6 +134,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
         /// <summary>
         /// Gets or sets the time at which the authentication ticket expires.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public DateTimeOffset? ExpiresUtc
         {
             get
@@ -163,6 +169,7 @@ namespace Microsoft.AspNetCore.Http.Authentication
         /// <summary>
         /// Gets or sets if refreshing the authentication session should be allowed.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public bool? AllowRefresh
         {
             get

--- a/src/Microsoft.AspNetCore.Http.Abstractions/HttpContext.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/HttpContext.cs
@@ -43,6 +43,7 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Gets an object that facilitates authentication for this request.
         /// </summary>
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public abstract AuthenticationManager Authentication { get; }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Http.Features/Authentication/AuthenticateContext.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/Authentication/AuthenticateContext.cs
@@ -7,6 +7,7 @@ using System.Security.Claims;
 
 namespace Microsoft.AspNetCore.Http.Features.Authentication
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class AuthenticateContext
     {
         public AuthenticateContext(string authenticationScheme)

--- a/src/Microsoft.AspNetCore.Http.Features/Authentication/ChallengeBehavior.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/Authentication/ChallengeBehavior.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNetCore.Http.Features.Authentication
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public enum ChallengeBehavior
     {
         Automatic,

--- a/src/Microsoft.AspNetCore.Http.Features/Authentication/ChallengeContext.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/Authentication/ChallengeContext.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Http.Features.Authentication
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class ChallengeContext
     {
         public ChallengeContext(string authenticationScheme)

--- a/src/Microsoft.AspNetCore.Http.Features/Authentication/DescribeSchemesContext.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/Authentication/DescribeSchemesContext.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Http.Features.Authentication
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class DescribeSchemesContext
     {
         private List<IDictionary<string, object>> _results;

--- a/src/Microsoft.AspNetCore.Http.Features/Authentication/IAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/Authentication/IAuthenticationHandler.cs
@@ -1,20 +1,27 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Http.Features.Authentication
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public interface IAuthenticationHandler
     {
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         void GetDescriptions(DescribeSchemesContext context);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         Task AuthenticateAsync(AuthenticateContext context);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         Task ChallengeAsync(ChallengeContext context);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         Task SignInAsync(SignInContext context);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         Task SignOutAsync(SignOutContext context);
     }
 }

--- a/src/Microsoft.AspNetCore.Http.Features/Authentication/IHttpAuthenticationFeature.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/Authentication/IHttpAuthenticationFeature.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Security.Claims;
 
 namespace Microsoft.AspNetCore.Http.Features.Authentication
@@ -9,6 +10,7 @@ namespace Microsoft.AspNetCore.Http.Features.Authentication
     {
         ClaimsPrincipal User { get; set; }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         IAuthenticationHandler Handler { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Http.Features/Authentication/SignInContext.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/Authentication/SignInContext.cs
@@ -7,6 +7,7 @@ using System.Security.Claims;
 
 namespace Microsoft.AspNetCore.Http.Features.Authentication
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class SignInContext
     {
         public SignInContext(string authenticationScheme, ClaimsPrincipal principal, IDictionary<string, string> properties)

--- a/src/Microsoft.AspNetCore.Http.Features/Authentication/SignOutContext.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/Authentication/SignOutContext.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Http.Features.Authentication
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class SignOutContext
     {
         public SignOutContext(string authenticationScheme, IDictionary<string, string> properties)

--- a/src/Microsoft.AspNetCore.Http/Authentication/DefaultAuthenticationManager.cs
+++ b/src/Microsoft.AspNetCore.Http/Authentication/DefaultAuthenticationManager.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http.Features.Authentication;
 
 namespace Microsoft.AspNetCore.Http.Authentication.Internal
 {
+    [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
     public class DefaultAuthenticationManager : AuthenticationManager
     {
         // Lambda hoisted to static readonly field to improve inlining https://github.com/dotnet/roslyn/issues/13624
@@ -35,11 +36,13 @@ namespace Microsoft.AspNetCore.Http.Authentication.Internal
             _features = default(FeatureReferences<IHttpAuthenticationFeature>);
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public override HttpContext HttpContext => _context;
 
         private IHttpAuthenticationFeature HttpAuthenticationFeature =>
             _features.Fetch(ref _features.Cache, _newAuthenticationFeature);
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public override IEnumerable<AuthenticationDescription> GetAuthenticationSchemes()
         {
             var handler = HttpAuthenticationFeature.Handler;
@@ -54,6 +57,7 @@ namespace Microsoft.AspNetCore.Http.Authentication.Internal
         }
 
         // Remove once callers have been switched to GetAuthenticateInfoAsync
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public override async Task AuthenticateAsync(AuthenticateContext context)
         {
             if (context == null)
@@ -73,6 +77,7 @@ namespace Microsoft.AspNetCore.Http.Authentication.Internal
             }
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public override async Task<AuthenticateInfo> GetAuthenticateInfoAsync(string authenticationScheme)
         {
             if (authenticationScheme == null)
@@ -100,6 +105,7 @@ namespace Microsoft.AspNetCore.Http.Authentication.Internal
             };
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public override async Task ChallengeAsync(string authenticationScheme, AuthenticationProperties properties, ChallengeBehavior behavior)
         {
             if (string.IsNullOrEmpty(authenticationScheme))
@@ -121,6 +127,7 @@ namespace Microsoft.AspNetCore.Http.Authentication.Internal
             }
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public override async Task SignInAsync(string authenticationScheme, ClaimsPrincipal principal, AuthenticationProperties properties)
         {
             if (string.IsNullOrEmpty(authenticationScheme))
@@ -147,6 +154,7 @@ namespace Microsoft.AspNetCore.Http.Authentication.Internal
             }
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public override async Task SignOutAsync(string authenticationScheme, AuthenticationProperties properties)
         {
             if (string.IsNullOrEmpty(authenticationScheme))

--- a/src/Microsoft.AspNetCore.Http/DefaultHttpContext.cs
+++ b/src/Microsoft.AspNetCore.Http/DefaultHttpContext.cs
@@ -28,7 +28,9 @@ namespace Microsoft.AspNetCore.Http
 
         private HttpRequest _request;
         private HttpResponse _response;
+#pragma warning disable 618
         private AuthenticationManager _authenticationManager;
+#pragma warning restore 618
         private ConnectionInfo _connection;
         private WebSocketManager _websockets;
 
@@ -66,7 +68,9 @@ namespace Microsoft.AspNetCore.Http
             }
             if (_authenticationManager != null)
             {
+#pragma warning disable 618
                 UninitializeAuthenticationManager(_authenticationManager);
+#pragma warning restore 618
                 _authenticationManager = null;
             }
             if (_connection != null)
@@ -111,6 +115,7 @@ namespace Microsoft.AspNetCore.Http
 
         public override ConnectionInfo Connection => _connection ?? (_connection = InitializeConnectionInfo());
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public override AuthenticationManager Authentication => _authenticationManager ?? (_authenticationManager = InitializeAuthenticationManager());
 
         public override WebSocketManager WebSockets => _websockets ?? (_websockets = InitializeWebSocketManager());
@@ -190,7 +195,9 @@ namespace Microsoft.AspNetCore.Http
         protected virtual ConnectionInfo InitializeConnectionInfo() => new DefaultConnectionInfo(Features);
         protected virtual void UninitializeConnectionInfo(ConnectionInfo instance) { }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         protected virtual AuthenticationManager InitializeAuthenticationManager() => new DefaultAuthenticationManager(this);
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         protected virtual void UninitializeAuthenticationManager(AuthenticationManager instance) { }
 
         protected virtual WebSocketManager InitializeWebSocketManager() => new DefaultWebSocketManager(Features);

--- a/src/Microsoft.AspNetCore.Http/Features/Authentication/HttpAuthenticationFeature.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/Authentication/HttpAuthenticationFeature.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Security.Claims;
 
 namespace Microsoft.AspNetCore.Http.Features.Authentication
@@ -13,6 +14,7 @@ namespace Microsoft.AspNetCore.Http.Features.Authentication
             set;
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         public IAuthenticationHandler Handler
         {
             get;

--- a/src/Microsoft.AspNetCore.Owin/OwinFeatureCollection.cs
+++ b/src/Microsoft.AspNetCore.Owin/OwinFeatureCollection.cs
@@ -279,6 +279,7 @@ namespace Microsoft.AspNetCore.Owin
             }
         }
 
+        [Obsolete("See https://go.microsoft.com/fwlink/?linkid=845470")]
         IAuthenticationHandler IHttpAuthenticationFeature.Handler { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Will go in when Security switches over to Auth 2.0 (this will require all Auth usages to switch over to 2.0 as well)