### PR TITLE
Improve DefaultHttpXxx default paths

### DIFF
--- a/samples/SampleApp/PooledHttpContext.cs
+++ b/samples/SampleApp/PooledHttpContext.cs
@@ -1,54 +1,86 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
 
 namespace SampleApp
 {
-    public class PooledHttpContext : DefaultHttpContext
+    public sealed class PooledHttpContext : HttpContext
     {
-        DefaultHttpRequest _pooledHttpRequest;
-        DefaultHttpResponse _pooledHttpResponse;
+        private readonly DefaultHttpContext _context;
 
-        public PooledHttpContext(IFeatureCollection featureCollection) :
-            base(featureCollection)
+        public PooledHttpContext(IFeatureCollection featureCollection)
         {
+            _context = new DefaultHttpContext(featureCollection);
         }
 
-        protected override HttpRequest InitializeHttpRequest()
+        public void Initialize(IFeatureCollection featureCollection)
         {
-            if (_pooledHttpRequest != null)
-            {
-                _pooledHttpRequest.Initialize(this);
-                return _pooledHttpRequest;
-            }
-
-            return new DefaultHttpRequest(this);
+            _context.Initialize(featureCollection);
         }
 
-        protected override void UninitializeHttpRequest(HttpRequest instance)
+        public void Uninitialize()
         {
-            _pooledHttpRequest = instance as DefaultHttpRequest;
-            _pooledHttpRequest?.Uninitialize();
+            _context.Uninitialize();
         }
 
-        protected override HttpResponse InitializeHttpResponse()
-        {
-            if (_pooledHttpResponse != null)
-            {
-                _pooledHttpResponse.Initialize(this);
-                return _pooledHttpResponse;
-            }
+        public override IFeatureCollection Features => _context.Features;
 
-            return new DefaultHttpResponse(this);
+        public override HttpRequest Request => _context.Request;
+
+        public override HttpResponse Response => _context.Response;
+
+        public override ConnectionInfo Connection => _context.Connection;
+
+        public override WebSocketManager WebSockets => _context.WebSockets;
+
+        public override AuthenticationManager Authentication => _context.Authentication;
+
+        public override ClaimsPrincipal User
+        {
+            get => _context.User;
+            set => _context.User = value;
         }
 
-        protected override void UninitializeHttpResponse(HttpResponse instance)
+        public override IDictionary<object, object> Items
         {
-            _pooledHttpResponse = instance as DefaultHttpResponse;
-            _pooledHttpResponse?.Uninitialize();
+            get => _context.Items;
+            set => _context.Items = value;
+        }
+
+        public override IServiceProvider RequestServices
+        {
+            get => _context.RequestServices;
+            set => _context.RequestServices = value;
+        }
+
+        public override CancellationToken RequestAborted
+        {
+            get => _context.RequestAborted;
+            set => _context.RequestAborted = value;
+        }
+
+        public override string TraceIdentifier
+        {
+            get => _context.TraceIdentifier;
+            set => _context.TraceIdentifier = value;
+        }
+
+        public override ISession Session
+        {
+            get => _context.Session;
+            set => _context.Session = value;
+        }
+
+        public override void Abort()
+        {
+            _context.Abort();
         }
     }
 }

--- a/samples/SampleApp/PooledHttpContextFactory.cs
+++ b/samples/SampleApp/PooledHttpContextFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.ObjectPool;

--- a/src/Microsoft.AspNetCore.Http.Features/FeatureReferences.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/FeatureReferences.cs
@@ -15,6 +15,13 @@ namespace Microsoft.AspNetCore.Http.Features
             Revision = collection.Revision;
         }
 
+        public FeatureReferences(IFeatureCollection collection, int featuresVersion)
+        {
+            Collection = collection;
+            Cache = default(TCache);
+            Revision = featuresVersion;
+        }
+
         public IFeatureCollection Collection { get; private set; }
         public int Revision { get; private set; }
 

--- a/src/Microsoft.AspNetCore.Http/Internal/DefaultConnectionInfo.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/DefaultConnectionInfo.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Http.Internal
 {
-    public class DefaultConnectionInfo : ConnectionInfo
+    public sealed class DefaultConnectionInfo : ConnectionInfo
     {
         // Lambdas hoisted to static readonly fields to improve inlining https://github.com/dotnet/roslyn/issues/13624
         private readonly static Func<IFeatureCollection, IHttpConnectionFeature> _newHttpConnectionFeature = f => new HttpConnectionFeature();
@@ -20,17 +20,7 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public DefaultConnectionInfo(IFeatureCollection features)
         {
-            Initialize(features);
-        }
-
-        public virtual void Initialize( IFeatureCollection features)
-        {
             _features = new FeatureReferences<FeatureInterfaces>(features);
-        }
-
-        public virtual void Uninitialize()
-        {
-            _features = default(FeatureReferences<FeatureInterfaces>);
         }
 
         private IHttpConnectionFeature HttpConnectionFeature =>

--- a/src/Microsoft.AspNetCore.Http/Internal/DefaultWebSocketManager.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/DefaultWebSocketManager.cs
@@ -10,7 +10,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Http.Internal
 {
-    public class DefaultWebSocketManager : WebSocketManager
+    public sealed class DefaultWebSocketManager : WebSocketManager
     {
         // Lambdas hoisted to static readonly fields to improve inlining https://github.com/dotnet/roslyn/issues/13624
         private readonly static Func<IFeatureCollection, IHttpRequestFeature> _nullRequestFeature = f => null;
@@ -20,17 +20,7 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public DefaultWebSocketManager(IFeatureCollection features)
         {
-            Initialize(features);
-        }
-
-        public virtual void Initialize(IFeatureCollection features)
-        {
             _features = new FeatureReferences<FeatureInterfaces>(features);
-        }
-
-        public virtual void Uninitialize()
-        {
-            _features = default(FeatureReferences<FeatureInterfaces>);
         }
 
         private IHttpRequestFeature HttpRequestFeature =>


### PR DESCRIPTION
* Reduce the number of (non-inlining) calls via interface to features `get_Version`
* Set up `IHttpRequestFeature` and `IHttpResponseFeature` while creating the context

Additionally there are compromises in `DefaultHttpXxx` for pooling; however this can be achieved without these compromises as well as improving the call chains to support devirtualization https://github.com/dotnet/coreclr/issues/9908.

* Implement `PooledHttpContext` though `DefaultHttpContext` rather than via inheritance.
* seal `DefaultHttpXxx` types to support devirtualization of overriden methods
* make `DefaultHttpXxx` private members direct types rather than parent types to support devirtualization
* Remove and don't call virtual methods from `DefaultHttpXxx` .ctors
* Make virtual methods in `DefaultHttpXxx` non-virtual

Non-DefaultHttpXxx can still be archived by inheriting from `HttpXxx` and either implementing via wrapping `DefaultHttpXxx` as per the Pooling example to make use of the feature caches; or by doing something alternative and using a completely different implementation.