### PR TITLE
Convert the header parsers to use StringSegment

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Extensions/HttpRequestMultipartExtensions.cs
+++ b/src/Microsoft.AspNetCore.Http.Extensions/HttpRequestMultipartExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
             {
                 return string.Empty;
             }
-            return HeaderUtilities.RemoveQuotes(mediaType.Boundary);
+            return HeaderUtilities.RemoveQuotes(mediaType.Boundary).ToString();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Http/Features/FormFeature.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/FormFeature.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Http.Features
@@ -293,14 +294,14 @@ namespace Microsoft.AspNetCore.Http.Features
         {
             // Content-Disposition: form-data; name="key";
             return contentDisposition != null && contentDisposition.DispositionType.Equals("form-data")
-                && string.IsNullOrEmpty(contentDisposition.FileName) && string.IsNullOrEmpty(contentDisposition.FileNameStar);
+                && StringSegment.IsNullOrEmpty(contentDisposition.FileName) && StringSegment.IsNullOrEmpty(contentDisposition.FileNameStar);
         }
 
         private bool HasFileContentDisposition(ContentDispositionHeaderValue contentDisposition)
         {
             // Content-Disposition: form-data; name="myfile1"; filename="Misc 002.jpg"
             return contentDisposition != null && contentDisposition.DispositionType.Equals("form-data")
-                && (!string.IsNullOrEmpty(contentDisposition.FileName) || !string.IsNullOrEmpty(contentDisposition.FileNameStar));
+                && (!StringSegment.IsNullOrEmpty(contentDisposition.FileName) || !StringSegment.IsNullOrEmpty(contentDisposition.FileNameStar));
         }
 
         // Content-Type: multipart/form-data; boundary="----WebKitFormBoundarymx2fSWqWSd0OxQqq"
@@ -308,7 +309,7 @@ namespace Microsoft.AspNetCore.Http.Features
         private static string GetBoundary(MediaTypeHeaderValue contentType, int lengthLimit)
         {
             var boundary = HeaderUtilities.RemoveQuotes(contentType.Boundary);
-            if (string.IsNullOrWhiteSpace(boundary))
+            if (StringSegment.IsNullOrEmpty(boundary))
             {
                 throw new InvalidDataException("Missing content-type boundary.");
             }
@@ -316,7 +317,7 @@ namespace Microsoft.AspNetCore.Http.Features
             {
                 throw new InvalidDataException($"Multipart boundary length limit {lengthLimit} exceeded.");
             }
-            return boundary;
+            return boundary.ToString();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Http/Internal/RequestCookieCollection.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/RequestCookieCollection.cs
@@ -75,8 +75,8 @@ namespace Microsoft.AspNetCore.Http.Internal
                 for (var i = 0; i < cookies.Count; i++)
                 {
                     var cookie = cookies[i];
-                    var name = Uri.UnescapeDataString(cookie.Name);
-                    var value = Uri.UnescapeDataString(cookie.Value);
+                    var name = Uri.UnescapeDataString(cookie.Name.Value);
+                    var value = Uri.UnescapeDataString(cookie.Value.Value);
                     store[name] = value;
                 }
 

--- a/src/Microsoft.AspNetCore.WebUtilities/FileMultipartSection.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FileMultipartSection.cs
@@ -39,11 +39,11 @@ namespace Microsoft.AspNetCore.WebUtilities
             Section = section;
             _contentDispositionHeader = header;
 
-            Name = HeaderUtilities.RemoveQuotes(_contentDispositionHeader.Name) ?? string.Empty;
+            Name = HeaderUtilities.RemoveQuotes(_contentDispositionHeader.Name).ToString();
             FileName = HeaderUtilities.RemoveQuotes(
-                    _contentDispositionHeader.FileNameStar ??
-                    _contentDispositionHeader.FileName ??
-                    string.Empty);
+                    _contentDispositionHeader.FileNameStar.HasValue ?
+                        _contentDispositionHeader.FileNameStar :
+                        _contentDispositionHeader.FileName).ToString();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.WebUtilities/FormMultipartSection.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/FormMultipartSection.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             Section = section;
             _contentDispositionHeader = header;
-            Name = HeaderUtilities.RemoveQuotes(_contentDispositionHeader.Name);
+            Name = HeaderUtilities.RemoveQuotes(_contentDispositionHeader.Name).ToString();
         }
 
         /// <summary>

--- a/src/Microsoft.Net.Http.Headers/BaseHeaderParser.cs
+++ b/src/Microsoft.Net.Http.Headers/BaseHeaderParser.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.Primitives;
+
 namespace Microsoft.Net.Http.Headers
 {
     internal abstract class BaseHeaderParser<T> : HttpHeaderParser<T>
@@ -10,9 +12,9 @@ namespace Microsoft.Net.Http.Headers
         {
         }
 
-        protected abstract int GetParsedValueLength(string value, int startIndex, out T parsedValue);
+        protected abstract int GetParsedValueLength(StringSegment value, int startIndex, out T parsedValue);
 
-        public sealed override bool TryParseValue(string value, ref int index, out T parsedValue)
+        public sealed override bool TryParseValue(StringSegment value, ref int index, out T parsedValue)
         {
             parsedValue = default(T);
 
@@ -21,7 +23,7 @@ namespace Microsoft.Net.Http.Headers
             //  Accept: text/xml; q=1
             //  Accept:
             //  Accept: text/plain; q=0.2
-            if (string.IsNullOrEmpty(value) || (index == value.Length))
+            if (StringSegment.IsNullOrEmpty(value) || (index == value.Length))
             {
                 return SupportsMultipleValues;
             }

--- a/src/Microsoft.Net.Http.Headers/ContentDispositionHeaderValueIdentityExtensions.cs
+++ b/src/Microsoft.Net.Http.Headers/ContentDispositionHeaderValueIdentityExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
@@ -23,7 +24,7 @@ namespace Microsoft.Net.Http.Headers
             }
 
             return header.DispositionType.Equals("form-data")
-                && (!string.IsNullOrEmpty(header.FileName) || !string.IsNullOrEmpty(header.FileNameStar));
+                && (!StringSegment.IsNullOrEmpty(header.FileName) || !StringSegment.IsNullOrEmpty(header.FileNameStar));
         }
 
         /// <summary>
@@ -39,7 +40,7 @@ namespace Microsoft.Net.Http.Headers
             }
 
             return header.DispositionType.Equals("form-data")
-               && string.IsNullOrEmpty(header.FileName) && string.IsNullOrEmpty(header.FileNameStar);
+               && StringSegment.IsNullOrEmpty(header.FileName) && StringSegment.IsNullOrEmpty(header.FileNameStar);
         }
     }
 }

--- a/src/Microsoft.Net.Http.Headers/CookieHeaderParser.cs
+++ b/src/Microsoft.Net.Http.Headers/CookieHeaderParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics.Contracts;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
@@ -12,7 +13,7 @@ namespace Microsoft.Net.Http.Headers
         {
         }
 
-        public sealed override bool TryParseValue(string value, ref int index, out CookieHeaderValue parsedValue)
+        public sealed override bool TryParseValue(StringSegment value, ref int index, out CookieHeaderValue parsedValue)
         {
             parsedValue = null;
 
@@ -21,7 +22,7 @@ namespace Microsoft.Net.Http.Headers
             //  Accept: text/xml; q=1
             //  Accept:
             //  Accept: text/plain; q=0.2
-            if (string.IsNullOrEmpty(value) || (index == value.Length))
+            if (StringSegment.IsNullOrEmpty(value) || (index == value.Length))
             {
                 return SupportsMultipleValues;
             }
@@ -62,7 +63,7 @@ namespace Microsoft.Net.Http.Headers
             return true;
         }
 
-        private static int GetNextNonEmptyOrWhitespaceIndex(string input, int startIndex, bool skipEmptyValues, out bool separatorFound)
+        private static int GetNextNonEmptyOrWhitespaceIndex(StringSegment input, int startIndex, bool skipEmptyValues, out bool separatorFound)
         {
             Contract.Requires(input != null);
             Contract.Requires(startIndex <= input.Length); // it's OK if index == value.Length.

--- a/src/Microsoft.Net.Http.Headers/GenericHeaderParser.cs
+++ b/src/Microsoft.Net.Http.Headers/GenericHeaderParser.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
     internal sealed class GenericHeaderParser<T> : BaseHeaderParser<T>
     {
-        internal delegate int GetParsedValueLengthDelegate(string value, int startIndex, out T parsedValue);
+        internal delegate int GetParsedValueLengthDelegate(StringSegment value, int startIndex, out T parsedValue);
 
         private GetParsedValueLengthDelegate _getParsedValueLength;
 
@@ -22,7 +23,7 @@ namespace Microsoft.Net.Http.Headers
             _getParsedValueLength = getParsedValueLength;
         }
 
-        protected override int GetParsedValueLength(string value, int startIndex, out T parsedValue)
+        protected override int GetParsedValueLength(StringSegment value, int startIndex, out T parsedValue)
         {
             return _getParsedValueLength(value, startIndex, out parsedValue);
         }

--- a/src/Microsoft.Net.Http.Headers/HeaderUtilities.cs
+++ b/src/Microsoft.Net.Http.Headers/HeaderUtilities.cs
@@ -72,9 +72,9 @@ namespace Microsoft.Net.Http.Headers
             return null;
         }
 
-        internal static void CheckValidToken(string value, string parameterName)
+        internal static void CheckValidToken(StringSegment value, string parameterName)
         {
-            if (string.IsNullOrEmpty(value))
+            if (StringSegment.IsNullOrEmpty(value))
             {
                 throw new ArgumentException("An empty string is not allowed.", parameterName);
             }
@@ -82,21 +82,6 @@ namespace Microsoft.Net.Http.Headers
             if (HttpRuleParser.GetTokenLength(value, 0) != value.Length)
             {
                 throw new FormatException(string.Format(CultureInfo.InvariantCulture, "Invalid token '{0}.", value));
-            }
-        }
-
-        internal static void CheckValidQuotedString(string value, string parameterName)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException("An empty string is not allowed.", parameterName);
-            }
-
-            int length;
-            if ((HttpRuleParser.GetQuotedStringLength(value, 0, out length) != HttpParseResult.Parsed) ||
-                (length != value.Length)) // no trailing spaces allowed
-            {
-                throw new FormatException(string.Format(CultureInfo.InvariantCulture, "Invalid quoted string '{0}'.", value));
             }
         }
 
@@ -167,7 +152,7 @@ namespace Microsoft.Net.Http.Headers
         }
 
         internal static int GetNextNonEmptyOrWhitespaceIndex(
-            string input,
+            StringSegment input,
             int startIndex,
             bool skipEmptyValues,
             out bool separatorFound)
@@ -368,11 +353,6 @@ namespace Microsoft.Net.Http.Headers
             return false;
         }
 
-        internal static bool TryParseNonNegativeInt32(string value, out int result)
-        {
-            return TryParseNonNegativeInt32(new StringSegment(value), out result);
-        }
-
         /// <summary>
         /// Try to convert a string representation of a positive number to its 64-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded or failed.
@@ -388,12 +368,7 @@ namespace Microsoft.Net.Http.Headers
         /// result will be overwritten.
         /// </param>
         /// <returns><code>true</code> if parsing succeeded; otherwise, <code>false</code>.</returns>
-        public static bool TryParseNonNegativeInt64(string value, out long result)
-        {
-            return TryParseNonNegativeInt64(new StringSegment(value), out result);
-        }
-
-        internal static unsafe bool TryParseNonNegativeInt32(StringSegment value, out int result)
+        public static unsafe bool TryParseNonNegativeInt32(StringSegment value, out int result)
         {
             if (string.IsNullOrEmpty(value.Buffer) || value.Length == 0)
             {
@@ -483,7 +458,7 @@ namespace Microsoft.Net.Http.Headers
         // Strict and fast RFC7231 5.3.1 Quality value parser (and without memory allocation)
         // See https://tools.ietf.org/html/rfc7231#section-5.3.1
         // Check is made to verify if the value is between 0 and 1 (and it returns False if the check fails).
-        internal static bool TryParseQualityDouble(string input, int startIndex, out double quality, out int length)
+        internal static bool TryParseQualityDouble(StringSegment input, int startIndex, out double quality, out int length)
         {
             quality = 0;
             length = 0;
@@ -602,7 +577,7 @@ namespace Microsoft.Net.Http.Headers
             return new string(charBuffer, position, _int64MaxStringLength - position);
         }
 
-        public static bool TryParseDate(string input, out DateTimeOffset result)
+        public static bool TryParseDate(StringSegment input, out DateTimeOffset result)
         {
             return HttpRuleParser.TryStringToDate(input, out result);
         }
@@ -617,11 +592,11 @@ namespace Microsoft.Net.Http.Headers
             return dateTime.ToRfc1123String(quoted);
         }
 
-        public static string RemoveQuotes(string input)
+        public static StringSegment RemoveQuotes(StringSegment input)
         {
-            if (!string.IsNullOrEmpty(input) && input.Length >= 2 && input[0] == '"' && input[input.Length - 1] == '"')
+            if (!StringSegment.IsNullOrEmpty(input) && input.Length >= 2 && input[0] == '"' && input[input.Length - 1] == '"')
             {
-                input = input.Substring(1, input.Length - 2);
+                input = input.Subsegment(1, input.Length - 2);
             }
             return input;
         }

--- a/src/Microsoft.Net.Http.Headers/HttpHeaderParser.cs
+++ b/src/Microsoft.Net.Http.Headers/HttpHeaderParser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
@@ -26,9 +27,9 @@ namespace Microsoft.Net.Http.Headers
         // pointing to the next non-whitespace character after a delimiter. E.g. if called with a start index of 0
         // for string "value , second_value", then after the call completes, 'index' must point to 's', i.e. the first
         // non-whitespace after the separator ','.
-        public abstract bool TryParseValue(string value, ref int index, out T parsedValue);
+        public abstract bool TryParseValue(StringSegment value, ref int index, out T parsedValue);
 
-        public T ParseValue(string value, ref int index)
+        public T ParseValue(StringSegment value, ref int index)
         {
             // Index may be value.Length (e.g. both 0). This may be allowed for some headers (e.g. Accept but not
             // allowed by others (e.g. Content-Length). The parser has to decide if this is valid or not.
@@ -40,7 +41,7 @@ namespace Microsoft.Net.Http.Headers
             if (!TryParseValue(value, ref index, out result))
             {
                 throw new FormatException(string.Format(CultureInfo.InvariantCulture,
-                    "The header contains invalid values at index {0}: '{1}'", index, value ?? "<null>"));
+                    "The header contains invalid values at index {0}: '{1}'", index, value.Value ?? "<null>"));
             }
             return result;
         }

--- a/src/Microsoft.Net.Http.Headers/HttpRuleParser.cs
+++ b/src/Microsoft.Net.Http.Headers/HttpRuleParser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Text;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
@@ -89,7 +90,7 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Pure]
-        internal static int GetTokenLength(string input, int startIndex)
+        internal static int GetTokenLength(StringSegment input, int startIndex)
         {
             Contract.Requires(input != null);
             Contract.Ensures((Contract.Result<int>() >= 0) && (Contract.Result<int>() <= (input.Length - startIndex)));
@@ -112,7 +113,7 @@ namespace Microsoft.Net.Http.Headers
             return input.Length - startIndex;
         }
 
-        internal static int GetWhitespaceLength(string input, int startIndex)
+        internal static int GetWhitespaceLength(StringSegment input, int startIndex)
         {
             Contract.Requires(input != null);
             Contract.Ensures((Contract.Result<int>() >= 0) && (Contract.Result<int>() <= (input.Length - startIndex)));
@@ -156,7 +157,7 @@ namespace Microsoft.Net.Http.Headers
             return input.Length - startIndex;
         }
 
-        internal static int GetNumberLength(string input, int startIndex, bool allowDecimal)
+        internal static int GetNumberLength(StringSegment input, int startIndex, bool allowDecimal)
         {
             Contract.Requires(input != null);
             Contract.Requires((startIndex >= 0) && (startIndex < input.Length));
@@ -201,7 +202,7 @@ namespace Microsoft.Net.Http.Headers
             return current - startIndex;
         }
 
-        internal static HttpParseResult GetQuotedStringLength(string input, int startIndex, out int length)
+        internal static HttpParseResult GetQuotedStringLength(StringSegment input, int startIndex, out int length)
         {
             var nestedCount = 0;
             return GetExpressionLength(input, startIndex, '"', '"', false, ref nestedCount, out length);
@@ -209,7 +210,7 @@ namespace Microsoft.Net.Http.Headers
 
         // quoted-pair = "\" CHAR
         // CHAR = <any US-ASCII character (octets 0 - 127)>
-        internal static HttpParseResult GetQuotedPairLength(string input, int startIndex, out int length)
+        internal static HttpParseResult GetQuotedPairLength(StringSegment input, int startIndex, out int length)
         {
             Contract.Requires(input != null);
             Contract.Requires((startIndex >= 0) && (startIndex < input.Length));
@@ -237,8 +238,8 @@ namespace Microsoft.Net.Http.Headers
 
         // Try the various date formats in the order listed above.
         // We should accept a wide verity of common formats, but only output RFC 1123 style dates.
-        internal static bool TryStringToDate(string input, out DateTimeOffset result) =>
-            DateTimeOffset.TryParseExact(input, DateFormats, DateTimeFormatInfo.InvariantInfo,
+        internal static bool TryStringToDate(StringSegment input, out DateTimeOffset result) =>
+            DateTimeOffset.TryParseExact(input.ToString(), DateFormats, DateTimeFormatInfo.InvariantInfo,
                 DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeUniversal, out result);
 
         // TEXT = <any OCTET except CTLs, but including LWS>
@@ -253,7 +254,7 @@ namespace Microsoft.Net.Http.Headers
         // comments, resulting in a stack overflow exception. In addition having more than 1 nested comment (if any)
         // is unusual.
         private static HttpParseResult GetExpressionLength(
-            string input,
+            StringSegment input,
             int startIndex,
             char openChar,
             char closeChar,

--- a/src/Microsoft.Net.Http.Headers/ObjectCollection.cs
+++ b/src/Microsoft.Net.Http.Headers/ObjectCollection.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Net.Http.Headers
     // type to throw if 'null' gets added. Collection<T> internally uses List<T> which comes at some cost. In addition
     // Collection<T>.Add() calls List<T>.InsertItem() which is an O(n) operation (compared to O(1) for List<T>.Add()).
     // This type is only used for very small collections (1-2 items) to keep the impact of using Collection<T> small.
-    internal class ObjectCollection<T> : Collection<T> where T : class
+    internal class ObjectCollection<T> : Collection<T>
     {
         internal static readonly Action<T> DefaultValidator = CheckNotNull;
         internal static readonly ObjectCollection<T> EmptyReadOnlyCollection

--- a/src/Microsoft.Net.Http.Headers/RangeConditionHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/RangeConditionHeaderValue.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.Contracts;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
@@ -85,26 +86,26 @@ namespace Microsoft.Net.Http.Headers
             return _entityTag.GetHashCode();
         }
 
-        public static RangeConditionHeaderValue Parse(string input)
+        public static RangeConditionHeaderValue Parse(StringSegment input)
         {
             var index = 0;
             return Parser.ParseValue(input, ref index);
         }
 
-        public static bool TryParse(string input, out RangeConditionHeaderValue parsedValue)
+        public static bool TryParse(StringSegment input, out RangeConditionHeaderValue parsedValue)
         {
             var index = 0;
             return Parser.TryParseValue(input, ref index, out parsedValue);
         }
 
-        private static int GetRangeConditionLength(string input, int startIndex, out RangeConditionHeaderValue parsedValue)
+        private static int GetRangeConditionLength(StringSegment input, int startIndex, out RangeConditionHeaderValue parsedValue)
         {
             Contract.Requires(startIndex >= 0);
 
             parsedValue = null;
 
             // Make sure we have at least 2 characters
-            if (string.IsNullOrEmpty(input) || (startIndex + 1 >= input.Length))
+            if (StringSegment.IsNullOrEmpty(input) || (startIndex + 1 >= input.Length))
             {
                 return 0;
             }
@@ -141,7 +142,7 @@ namespace Microsoft.Net.Http.Headers
             }
             else
             {
-                if (!HttpRuleParser.TryStringToDate(input.Substring(current), out date))
+                if (!HttpRuleParser.TryStringToDate(input.Subsegment(current), out date))
                 {
                     return 0;
                 }

--- a/src/Microsoft.Net.Http.Headers/RangeItemHeaderValue.cs
+++ b/src/Microsoft.Net.Http.Headers/RangeItemHeaderValue.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
@@ -87,7 +88,7 @@ namespace Microsoft.Net.Http.Headers
         // Returns the length of a range list. E.g. "1-2, 3-4, 5-6" adds 3 ranges to 'rangeCollection'. Note that empty
         // list segments are allowed, e.g. ",1-2, , 3-4,,".
         internal static int GetRangeItemListLength(
-            string input,
+            StringSegment input,
             int startIndex,
             ICollection<RangeItemHeaderValue> rangeCollection)
         {
@@ -96,7 +97,7 @@ namespace Microsoft.Net.Http.Headers
             Contract.Ensures((Contract.Result<int>() == 0) || (rangeCollection.Count > 0),
                 "If we can parse the string, then we expect to have at least one range item.");
 
-            if ((string.IsNullOrEmpty(input)) || (startIndex >= input.Length))
+            if ((StringSegment.IsNullOrEmpty(input)) || (startIndex >= input.Length))
             {
                 return 0;
             }
@@ -140,7 +141,7 @@ namespace Microsoft.Net.Http.Headers
             }
         }
 
-        internal static int GetRangeItemLength(string input, int startIndex, out RangeItemHeaderValue parsedValue)
+        internal static int GetRangeItemLength(StringSegment input, int startIndex, out RangeItemHeaderValue parsedValue)
         {
             Contract.Requires(startIndex >= 0);
 
@@ -148,7 +149,7 @@ namespace Microsoft.Net.Http.Headers
 
             parsedValue = null;
 
-            if (string.IsNullOrEmpty(input) || (startIndex >= input.Length))
+            if (StringSegment.IsNullOrEmpty(input) || (startIndex >= input.Length))
             {
                 return 0;
             }
@@ -202,14 +203,14 @@ namespace Microsoft.Net.Http.Headers
 
             // Try convert first value to int64
             long from = 0;
-            if ((fromLength > 0) && !HeaderUtilities.TryParseNonNegativeInt64(input.Substring(fromStartIndex, fromLength), out from))
+            if ((fromLength > 0) && !HeaderUtilities.TryParseNonNegativeInt64(input.Subsegment(fromStartIndex, fromLength), out from))
             {
                 return 0;
             }
 
             // Try convert second value to int64
             long to = 0;
-            if ((toLength > 0) && !HeaderUtilities.TryParseNonNegativeInt64(input.Substring(toStartIndex, toLength), out to))
+            if ((toLength > 0) && !HeaderUtilities.TryParseNonNegativeInt64(input.Subsegment(toStartIndex, toLength), out to))
             {
                 return 0;
             }

--- a/src/Microsoft.Net.Http.Headers/StringWithQualityHeaderValueComparer.cs
+++ b/src/Microsoft.Net.Http.Headers/StringWithQualityHeaderValueComparer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Net.Http.Headers
 {
@@ -64,13 +65,13 @@ namespace Microsoft.Net.Http.Headers
                 return 1;
             }
 
-            if (!string.Equals(stringWithQuality1.Value, stringWithQuality2.Value, StringComparison.OrdinalIgnoreCase))
+            if (!StringSegment.Equals(stringWithQuality1.Value, stringWithQuality2.Value, StringComparison.OrdinalIgnoreCase))
             {
-                if (string.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
+                if (StringSegment.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
                 {
                     return -1;
                 }
-                else if (string.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
+                else if (StringSegment.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
                 {
                     return 1;
                 }

--- a/test/Microsoft.Net.Http.Headers.Tests/ContentDispositionHeaderValueTest.cs
+++ b/test/Microsoft.Net.Http.Headers.Tests/ContentDispositionHeaderValueTest.cs
@@ -46,8 +46,8 @@ namespace Microsoft.Net.Http.Headers
             var contentDisposition = new ContentDispositionHeaderValue("inline");
             Assert.Equal("inline", contentDisposition.DispositionType);
             Assert.Equal(0, contentDisposition.Parameters.Count);
-            Assert.Null(contentDisposition.Name);
-            Assert.Null(contentDisposition.FileName);
+            Assert.Null(contentDisposition.Name.Value);
+            Assert.Null(contentDisposition.FileName.Value);
             Assert.Null(contentDisposition.CreationDate);
             Assert.Null(contentDisposition.ModificationDate);
             Assert.Null(contentDisposition.ReadDate);
@@ -81,7 +81,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("name", contentDisposition.Parameters.First().Name);
 
             contentDisposition.Name = null;
-            Assert.Null(contentDisposition.Name);
+            Assert.Null(contentDisposition.Name.Value);
             Assert.Equal(0, contentDisposition.Parameters.Count);
             contentDisposition.Name = null; // It's OK to set it again to null; no exception.
         }
@@ -103,7 +103,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("NAME", contentDisposition.Parameters.First().Name);
 
             contentDisposition.Parameters.Remove(name);
-            Assert.Null(contentDisposition.Name);
+            Assert.Null(contentDisposition.Name.Value);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("FILENAME", contentDisposition.Parameters.First().Name);
 
             contentDisposition.Parameters.Remove(fileName);
-            Assert.Null(contentDisposition.FileName);
+            Assert.Null(contentDisposition.FileName.Value);
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("\"=?utf-8?B?RmlsZcODTmFtZS5iYXQ=?=\"", contentDisposition.Parameters.First().Value);
 
             contentDisposition.Parameters.Remove(contentDisposition.Parameters.First());
-            Assert.Null(contentDisposition.FileName);
+            Assert.Null(contentDisposition.FileName.Value);
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("FILENAME", contentDisposition.Parameters.First().Name);
 
             contentDisposition.Parameters.Remove(fileName);
-            Assert.Null(contentDisposition.FileName);
+            Assert.Null(contentDisposition.FileName.Value);
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace Microsoft.Net.Http.Headers
             contentDisposition.Parameters.Add(fileNameStar);
             Assert.Equal(1, contentDisposition.Parameters.Count);
             Assert.Equal("FILENAME*", contentDisposition.Parameters.First().Name);
-            Assert.Null(contentDisposition.FileNameStar); // Decode failure
+            Assert.Null(contentDisposition.FileNameStar.Value); // Decode failure
 
             contentDisposition.FileNameStar = "new_name";
             Assert.Equal("new_name", contentDisposition.FileNameStar);
@@ -182,7 +182,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("UTF-8\'\'new_name", contentDisposition.Parameters.First().Value);
 
             contentDisposition.Parameters.Remove(fileNameStar);
-            Assert.Null(contentDisposition.FileNameStar);
+            Assert.Null(contentDisposition.FileNameStar.Value);
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("UTF-8\'\'File%C3%83Name.bat", contentDisposition.Parameters.First().Value);
 
             contentDisposition.Parameters.Remove(contentDisposition.Parameters.First());
-            Assert.Null(contentDisposition.FileNameStar);
+            Assert.Null(contentDisposition.FileNameStar.Value);
         }
 
         [Fact]
@@ -211,7 +211,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(1, contentDisposition.Parameters.Count);
             Assert.Equal("FILENAME*", contentDisposition.Parameters.First().Name);
             Assert.Equal("utf-99'lang'File%CZName.bat", contentDisposition.Parameters.First().Value);
-            Assert.Null(contentDisposition.FileNameStar); // Decode failure
+            Assert.Null(contentDisposition.FileNameStar.Value); // Decode failure
 
             contentDisposition.FileNameStar = "new_name";
             Assert.Equal("new_name", contentDisposition.FileNameStar);
@@ -219,7 +219,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("FILENAME*", contentDisposition.Parameters.First().Name);
 
             contentDisposition.Parameters.Remove(fileNameStar);
-            Assert.Null(contentDisposition.FileNameStar);
+            Assert.Null(contentDisposition.FileNameStar.Value);
         }
 
         [Fact]

--- a/test/Microsoft.Net.Http.Headers.Tests/MediaTypeHeaderValueTest.cs
+++ b/test/Microsoft.Net.Http.Headers.Tests/MediaTypeHeaderValueTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Net.Http.Headers
             var mediaType = new MediaTypeHeaderValue("text/plain");
             Assert.Equal("text/plain", mediaType.MediaType);
             Assert.Equal(0, mediaType.Parameters.Count);
-            Assert.Null(mediaType.Charset);
+            Assert.Null(mediaType.Charset.Value);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Microsoft.Net.Http.Headers
             var mediaType0 = new MediaTypeHeaderValue("text/plain");
             var mediaType1 = mediaType0.Copy();
             Assert.NotSame(mediaType0, mediaType1);
-            Assert.Same(mediaType0.MediaType, mediaType1.MediaType);
+            Assert.Same(mediaType0.MediaType.Value, mediaType1.MediaType.Value);
             Assert.NotSame(mediaType0.Parameters, mediaType1.Parameters);
             Assert.Equal(mediaType0.Parameters.Count, mediaType1.Parameters.Count);
         }
@@ -81,7 +81,7 @@ namespace Microsoft.Net.Http.Headers
             var mediaType0 = new MediaTypeHeaderValue("text/plain");
             var mediaType1 = mediaType0.CopyAsReadOnly();
             Assert.NotSame(mediaType0, mediaType1);
-            Assert.Same(mediaType0.MediaType, mediaType1.MediaType);
+            Assert.Same(mediaType0.MediaType.Value, mediaType1.MediaType.Value);
             Assert.NotSame(mediaType0.Parameters, mediaType1.Parameters);
             Assert.Equal(mediaType0.Parameters.Count, mediaType1.Parameters.Count);
 
@@ -97,14 +97,14 @@ namespace Microsoft.Net.Http.Headers
             mediaType0.Parameters.Add(new NameValueHeaderValue("name", "value"));
             var mediaType1 = mediaType0.Copy();
             Assert.NotSame(mediaType0, mediaType1);
-            Assert.Same(mediaType0.MediaType, mediaType1.MediaType);
+            Assert.Same(mediaType0.MediaType.Value, mediaType1.MediaType.Value);
             Assert.NotSame(mediaType0.Parameters, mediaType1.Parameters);
             Assert.Equal(mediaType0.Parameters.Count, mediaType1.Parameters.Count);
             var pair0 = mediaType0.Parameters.First();
             var pair1 = mediaType1.Parameters.First();
             Assert.NotSame(pair0, pair1);
-            Assert.Same(pair0.Name, pair1.Name);
-            Assert.Same(pair0.Value, pair1.Value);
+            Assert.Same(pair0.Name.Value, pair1.Name.Value);
+            Assert.Same(pair0.Value.Value, pair1.Value.Value);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.NotSame(mediaType0, mediaType1);
             Assert.False(mediaType0.IsReadOnly);
             Assert.True(mediaType1.IsReadOnly);
-            Assert.Same(mediaType0.MediaType, mediaType1.MediaType);
+            Assert.Same(mediaType0.MediaType.Value, mediaType1.MediaType.Value);
 
             Assert.NotSame(mediaType0.Parameters, mediaType1.Parameters);
             Assert.False(mediaType0.Parameters.IsReadOnly);
@@ -131,8 +131,8 @@ namespace Microsoft.Net.Http.Headers
             Assert.NotSame(pair0, pair1);
             Assert.False(pair0.IsReadOnly);
             Assert.True(pair1.IsReadOnly);
-            Assert.Same(pair0.Name, pair1.Name);
-            Assert.Same(pair0.Value, pair1.Value);
+            Assert.Same(pair0.Name.Value, pair1.Name.Value);
+            Assert.Same(pair0.Value.Value, pair1.Value.Value);
         }
 
         [Fact]
@@ -144,7 +144,7 @@ namespace Microsoft.Net.Http.Headers
             var mediaType2 = mediaType1.Copy();
 
             Assert.NotSame(mediaType2, mediaType1);
-            Assert.Same(mediaType2.MediaType, mediaType1.MediaType);
+            Assert.Same(mediaType2.MediaType.Value, mediaType1.MediaType.Value);
             Assert.True(mediaType1.IsReadOnly);
             Assert.False(mediaType2.IsReadOnly);
             Assert.NotSame(mediaType2.Parameters, mediaType1.Parameters);
@@ -154,8 +154,8 @@ namespace Microsoft.Net.Http.Headers
             Assert.NotSame(pair2, pair1);
             Assert.True(pair1.IsReadOnly);
             Assert.False(pair2.IsReadOnly);
-            Assert.Same(pair2.Name, pair1.Name);
-            Assert.Same(pair2.Value, pair1.Value);
+            Assert.Same(pair2.Name.Value, pair1.Name.Value);
+            Assert.Same(pair2.Value.Value, pair1.Value.Value);
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("charset", mediaType.Parameters.First().Name);
 
             mediaType.Charset = null;
-            Assert.Null(mediaType.Charset);
+            Assert.Null(mediaType.Charset.Value);
             Assert.Equal(0, mediaType.Parameters.Count);
             mediaType.Charset = null; // It's OK to set it again to null; no exception.
         }
@@ -200,7 +200,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal("CHARSET", mediaType.Parameters.First().Name);
 
             mediaType.Parameters.Remove(charset);
-            Assert.Null(mediaType.Charset);
+            Assert.Null(mediaType.Charset.Value);
         }
 
         [Fact]

--- a/test/Microsoft.Net.Http.Headers.Tests/NameValueHeaderValueTest.cs
+++ b/test/Microsoft.Net.Http.Headers.Tests/NameValueHeaderValueTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -65,14 +65,14 @@ namespace Microsoft.Net.Http.Headers
             var pair0 = new NameValueHeaderValue("name");
             var pair1 = pair0.Copy();
             Assert.NotSame(pair0, pair1);
-            Assert.Same(pair0.Name, pair1.Name);
-            Assert.Null(pair0.Value);
-            Assert.Null(pair1.Value);
+            Assert.Same(pair0.Name.Value, pair1.Name.Value);
+            Assert.Null(pair0.Value.Value);
+            Assert.Null(pair1.Value.Value);
 
             // Change one value and verify the other is unchanged.
             pair0.Value = "othervalue";
             Assert.Equal("othervalue", pair0.Value);
-            Assert.Null(pair1.Value);
+            Assert.Null(pair1.Value.Value);
         }
 
         [Fact]
@@ -81,16 +81,16 @@ namespace Microsoft.Net.Http.Headers
             var pair0 = new NameValueHeaderValue("name");
             var pair1 = pair0.CopyAsReadOnly();
             Assert.NotSame(pair0, pair1);
-            Assert.Same(pair0.Name, pair1.Name);
-            Assert.Null(pair0.Value);
-            Assert.Null(pair1.Value);
+            Assert.Same(pair0.Name.Value, pair1.Name.Value);
+            Assert.Null(pair0.Value.Value);
+            Assert.Null(pair1.Value.Value);
             Assert.False(pair0.IsReadOnly);
             Assert.True(pair1.IsReadOnly);
 
             // Change one value and verify the other is unchanged.
             pair0.Value = "othervalue";
             Assert.Equal("othervalue", pair0.Value);
-            Assert.Null(pair1.Value);
+            Assert.Null(pair1.Value.Value);
             Assert.Throws<InvalidOperationException>(() => { pair1.Value = "othervalue"; });
         }
 
@@ -100,8 +100,8 @@ namespace Microsoft.Net.Http.Headers
             var pair0 = new NameValueHeaderValue("name", "value");
             var pair1 = pair0.Copy();
             Assert.NotSame(pair0, pair1);
-            Assert.Same(pair0.Name, pair1.Name);
-            Assert.Same(pair0.Value, pair1.Value);
+            Assert.Same(pair0.Name.Value, pair1.Name.Value);
+            Assert.Same(pair0.Value.Value, pair1.Value.Value);
 
             // Change one value and verify the other is unchanged.
             pair0.Value = "othervalue";
@@ -115,8 +115,8 @@ namespace Microsoft.Net.Http.Headers
             var pair0 = new NameValueHeaderValue("name", "value");
             var pair1 = pair0.CopyAsReadOnly();
             Assert.NotSame(pair0, pair1);
-            Assert.Same(pair0.Name, pair1.Name);
-            Assert.Same(pair0.Value, pair1.Value);
+            Assert.Same(pair0.Name.Value, pair1.Name.Value);
+            Assert.Same(pair0.Value.Value, pair1.Value.Value);
             Assert.False(pair0.IsReadOnly);
             Assert.True(pair1.IsReadOnly);
 
@@ -134,8 +134,8 @@ namespace Microsoft.Net.Http.Headers
             var pair1 = pair0.CopyAsReadOnly();
             var pair2 = pair1.Copy();
             Assert.NotSame(pair0, pair1);
-            Assert.Same(pair0.Name, pair1.Name);
-            Assert.Same(pair0.Value, pair1.Value);
+            Assert.Same(pair0.Name.Value, pair1.Name.Value);
+            Assert.Same(pair0.Value.Value, pair1.Value.Value);
 
             // Change one value and verify the other is unchanged.
             pair2.Value = "othervalue";


### PR DESCRIPTION
#758 This primarily covers Microsoft.Net.Http.Headers, and reactions to those changes. As a rule I changed all strings to StringSegments where sensible, but did not expose it on the user friendly APIs like Form.

Working on the reactions across the Universe.