### PR TITLE
Upgrade corefx packages to 4.4.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>


### PR DESCRIPTION
Follow up to #840 

This repo uses CoreFxVersion value to set the version System.Buffers and System.Text.Encodings.Web. Both of these havea 4.4.0-* package that better supports ns2.0 and netcoreapp2.0 than the 4.3.0 versions.

See https://dotnet.myget.org/feed/dotnet-core/package/nuget/System.Buffers/4.4.0-preview2-25324-02 and https://dotnet.myget.org/feed/dotnet-core/package/nuget/System.Text.Encodings.Web/4.4.0-preview2-25324-02

FYI - @pranavkm @kichalla @dougbu 