### PR TITLE
Proposal: Change default challenge and forbid behavior

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Core/AuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Core/AuthenticationService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Authentication
 {
@@ -89,14 +90,17 @@ namespace Microsoft.AspNetCore.Authentication
                 scheme = defaultChallengeScheme?.Name;
                 if (scheme == null)
                 {
-                    throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultChallengeScheme found.");
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    return;
                 }
             }
 
             var handler = await Handlers.GetHandlerAsync(context, scheme);
             if (handler == null)
             {
-                throw new InvalidOperationException($"No authentication handler is configured to handle the scheme: {scheme}");
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                context.Response.Headers[HeaderNames.WWWAuthenticate] = scheme;
+                return;
             }
 
             await handler.ChallengeAsync(properties);
@@ -117,7 +121,8 @@ namespace Microsoft.AspNetCore.Authentication
                 scheme = defaultChallengeScheme?.Name;
                 if (scheme == null)
                 {
-                    throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultChallengeScheme found.");
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    return;
                 }
             }
 


### PR DESCRIPTION
- ChallengeAsync with a scheme that has no handler will send a 401 with a
WWW-Authenticate header matching that scheme.
- ChallengeAsync without a scheme and
- ForbidAsync returns a 403 by default and continues to throw if there's no handler
for the specified scheme if any.

PS: This is a PR for discussion.