### PR TITLE
Deprecate the Form property and ReadForm() method on IFormFeature

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Abstractions/HttpRequest.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/HttpRequest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -108,6 +109,7 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Gets or sets the request body as a form.
         /// </summary>
+        [Obsolete("This is obsolete and will be removed in a future version. The recommended alternative is to use Microsoft.AspNetCore.Http.HttpRequest.ReadFormAsync(). See TODO")]
         public abstract IFormCollection Form { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Http.Features/IFormFeature.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/IFormFeature.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +23,7 @@ namespace Microsoft.AspNetCore.Http.Features
         /// Parses the request body as a form.
         /// </summary>
         /// <returns></returns>
+        [Obsolete("This is obsolete and will be removed in a future version. The recommended alternative is to use Microsoft.AspNetCore.Http.Features.IFormFeature.ReadFormAsync(). See TODO")]
         IFormCollection ReadForm();
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Http/Features/FormFeature.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/FormFeature.cs
@@ -86,6 +86,7 @@ namespace Microsoft.AspNetCore.Http.Features
             }
         }
 
+        [Obsolete("This is obsolete and will be removed in a future version. The recommended alternative is to use Microsoft.AspNetCore.Http.Features.FormFeature.ReadFormAsync(). See TODO")]
         public IFormCollection ReadForm()
         {
             if (Form != null)

--- a/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpRequest.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpRequest.cs
@@ -140,6 +140,7 @@ namespace Microsoft.AspNetCore.Http.Internal
             get { return FormFeature.HasFormContentType; }
         }
 
+        [Obsolete("This is obsolete and will be removed in a future version. The recommended alternative is to use Microsoft.AspNetCore.Http.Internal.DefaultHttpRequest.ReadFormAsync(). See TODO")]
         public override IFormCollection Form
         {
             get { return FormFeature.ReadForm(); }

--- a/test/Microsoft.AspNetCore.Http.Tests/Features/FormFeatureTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/Features/FormFeatureTests.cs
@@ -103,7 +103,9 @@ namespace Microsoft.AspNetCore.Http.Features
             IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
             context.Features.Set<IFormFeature>(formFeature);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var formCollection = context.Request.Form;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.NotNull(formCollection);
 
@@ -138,7 +140,9 @@ namespace Microsoft.AspNetCore.Http.Features
             IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
             context.Features.Set<IFormFeature>(formFeature);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var formCollection = context.Request.Form;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.NotNull(formCollection);
 
@@ -184,7 +188,9 @@ namespace Microsoft.AspNetCore.Http.Features
             Assert.NotNull(formFeature);
             Assert.NotNull(formFeature.Form);
             Assert.Same(formFeature.Form, formCollection);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Same(formCollection, context.Request.Form);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Content
             Assert.Equal(0, formCollection.Count);
@@ -232,7 +238,9 @@ namespace Microsoft.AspNetCore.Http.Features
             Assert.NotNull(formFeature);
             Assert.NotNull(formFeature.Form);
             Assert.Same(formFeature.Form, formCollection);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Same(formCollection, context.Request.Form);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Content
             Assert.Equal(0, formCollection.Count);
@@ -280,7 +288,9 @@ namespace Microsoft.AspNetCore.Http.Features
             Assert.NotNull(formFeature);
             Assert.NotNull(formFeature.Form);
             Assert.Same(formFeature.Form, formCollection);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Same(formCollection, context.Request.Form);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Content
             Assert.Equal(1, formCollection.Count);
@@ -382,7 +392,9 @@ namespace Microsoft.AspNetCore.Http.Features
             Assert.NotNull(formFeature);
             Assert.NotNull(formFeature.Form);
             Assert.Same(formFeature.Form, formCollection);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Same(formCollection, context.Request.Form);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Content
             Assert.Equal(1, formCollection.Count);


### PR DESCRIPTION
- The Form property on the IFormFeature is kept around as a backing
store for ReadFormAsync(). Middleware can still set it to change
the results of ReadFormAsync by setting the Form property on the feature directly.

PS: I need an FW link

#796