### PR TITLE
Remove unused parameter in ctor of HttpContextFactory

### DIFF
--- a/src/Microsoft.AspNetCore.Http/HttpContextFactory.cs
+++ b/src/Microsoft.AspNetCore.Http/HttpContextFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Http
@@ -13,17 +12,13 @@ namespace Microsoft.AspNetCore.Http
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly FormOptions _formOptions;
 
-        public HttpContextFactory(ObjectPoolProvider poolProvider, IOptions<FormOptions> formOptions)
-            : this(poolProvider, formOptions, httpContextAccessor: null)
+        public HttpContextFactory(IOptions<FormOptions> formOptions)
+            : this(formOptions, httpContextAccessor: null)
         {
         }
 
-        public HttpContextFactory(ObjectPoolProvider poolProvider, IOptions<FormOptions> formOptions, IHttpContextAccessor httpContextAccessor)
+        public HttpContextFactory(IOptions<FormOptions> formOptions, IHttpContextAccessor httpContextAccessor)
         {
-            if (poolProvider == null)
-            {
-                throw new ArgumentNullException(nameof(poolProvider));
-            }
             if (formOptions == null)
             {
                 throw new ArgumentNullException(nameof(formOptions));

--- a/src/Microsoft.AspNetCore.Http/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.Http/breakingchanges.netcore.json
@@ -1,0 +1,12 @@
+﻿  [
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.HttpContextFactory : Microsoft.AspNetCore.Http.IHttpContextFactory",
+      "MemberId": "public .ctor(Microsoft.Extensions.ObjectPool.ObjectPoolProvider poolProvider, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Http.Features.FormOptions> formOptions)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.HttpContextFactory : Microsoft.AspNetCore.Http.IHttpContextFactory",
+      "MemberId": "public .ctor(Microsoft.Extensions.ObjectPool.ObjectPoolProvider poolProvider, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Http.Features.FormOptions> formOptions, Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor)",
+      "Kind": "Removal"
+    }
+  ]

--- a/test/Microsoft.AspNetCore.Http.Tests/HttpContextFactoryTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/HttpContextFactoryTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -17,7 +16,7 @@ namespace Microsoft.AspNetCore.Http
         {
             // Arrange
             var accessor = new HttpContextAccessor();
-            var contextFactory = new HttpContextFactory(new DefaultObjectPoolProvider(), Options.Create(new FormOptions()), accessor);
+            var contextFactory = new HttpContextFactory(Options.Create(new FormOptions()), accessor);
 
             // Act
             var context = contextFactory.Create(new FeatureCollection());
@@ -30,7 +29,7 @@ namespace Microsoft.AspNetCore.Http
         public void AllowsCreatingContextWithoutSettingAccessor()
         {
             // Arrange
-            var contextFactory = new HttpContextFactory(new DefaultObjectPoolProvider(), Options.Create(new FormOptions()));
+            var contextFactory = new HttpContextFactory(Options.Create(new FormOptions()));
 
             // Act & Assert
             var context = contextFactory.Create(new FeatureCollection());


### PR DESCRIPTION
- We removed the use of the ObjectPoolProvider in 1.x, this change
just removes it from the ctor.

There's a single reference here:
https://github.com/aspnet/Hosting/blob/7890fdbf94df7463047ba05865b8f515d029e057/test/Microsoft.AspNetCore.Hosting.Tests/HostingApplicationTests.cs#L265