### PR TITLE
Add opt out flags for Auth defaults

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Abstractions/AuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Abstractions/AuthenticationOptions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Authentication
             });
 
         /// <summary>
-        /// The scheme that will should be authenticated automatically used to set <see cref="HttpContext.User"/>"/>.
+        /// The scheme that should be authenticated automatically to set <see cref="HttpContext.User"/>"/>.
         /// </summary>
         public string AutomaticAuthenticateScheme { get; set; }
 
@@ -81,12 +81,12 @@ namespace Microsoft.AspNetCore.Authentication
         public string DefaultSignOutScheme { get; set; }
 
         /// <summary>
-        /// Used by as the default scheme by <see cref="IAuthenticationService.ChallengeAsync(HttpContext, string, AuthenticationProperties)"/>.
+        /// Used as the default scheme by <see cref="IAuthenticationService.ChallengeAsync(HttpContext, string, AuthenticationProperties)"/>.
         /// </summary>
         public string DefaultChallengeScheme { get; set; }
 
         /// <summary>
-        /// Used by as the default scheme by <see cref="IAuthenticationService.ForbidAsync(HttpContext, string, AuthenticationProperties)"/>.
+        /// Used as the default scheme by <see cref="IAuthenticationService.ForbidAsync(HttpContext, string, AuthenticationProperties)"/>.
         /// </summary>
         public string DefaultForbidScheme { get; set; }
 

--- a/src/Microsoft.AspNetCore.Authentication.Abstractions/AuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Abstractions/AuthenticationOptions.cs
@@ -61,17 +61,22 @@ namespace Microsoft.AspNetCore.Authentication
             });
 
         /// <summary>
-        /// Used by as the default scheme by <see cref="IAuthenticationService.AuthenticateAsync(HttpContext, string)"/>.
+        /// The scheme that will should be authenticated automatically used to set <see cref="HttpContext.User"/>"/>.
+        /// </summary>
+        public string AutomaticAuthenticateScheme { get; set; }
+
+        /// <summary>
+        /// Used as the default scheme by <see cref="IAuthenticationService.AuthenticateAsync(HttpContext, string)"/>.
         /// </summary>
         public string DefaultAuthenticateScheme { get; set; }
 
         /// <summary>
-        /// Used by as the default scheme by <see cref="IAuthenticationService.SignInAsync(HttpContext, string, System.Security.Claims.ClaimsPrincipal, AuthenticationProperties)"/>.
+        /// Used as the default scheme by <see cref="IAuthenticationService.SignInAsync(HttpContext, string, System.Security.Claims.ClaimsPrincipal, AuthenticationProperties)"/>.
         /// </summary>
         public string DefaultSignInScheme { get; set; }
 
         /// <summary>
-        /// Used by as the default scheme by <see cref="IAuthenticationService.SignOutAsync(HttpContext, string, AuthenticationProperties)"/>.
+        /// Used as the default scheme by <see cref="IAuthenticationService.SignOutAsync(HttpContext, string, AuthenticationProperties)"/>.
         /// </summary>
         public string DefaultSignOutScheme { get; set; }
 
@@ -84,5 +89,19 @@ namespace Microsoft.AspNetCore.Authentication
         /// Used by as the default scheme by <see cref="IAuthenticationService.ForbidAsync(HttpContext, string, AuthenticationProperties)"/>.
         /// </summary>
         public string DefaultForbidScheme { get; set; }
+
+        /// <summary>
+        /// If set, the default <see cref="IAuthenticationSchemeProvider"/> will attempt to fallback logic when 
+        /// Default[Authenticate/SignIn/SignOut/Challenge/Forbid]Schemes are not set.
+        /// This is enabled by default.
+        /// </summary>
+        public bool EnableDefaultFallback { get; set; } = true;
+
+        /// <summary>
+        /// If <see cref="EnableDefaultFallback"/> and this are both true, the default <see cref="IAuthenticationSchemeProvider"/> will use a single handler as the default for 
+        /// the Default[Authenticate/SignIn/SignOut/Challenge/Forbid]Schemes.
+        /// This is enabled by default.
+        /// </summary>
+        public bool EnableDefaultSingleHandlerFallback { get; set; } = true;
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Abstractions/IAuthenticationSchemeProvider.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Abstractions/IAuthenticationSchemeProvider.cs
@@ -26,6 +26,14 @@ namespace Microsoft.AspNetCore.Authentication
         Task<AuthenticationScheme> GetSchemeAsync(string name);
 
         /// <summary>
+        /// Returns the scheme that should be used to set <see cref="HttpContext.User"/>.
+        /// This is typically specified via <see cref="AuthenticationOptions.AutomaticAuthenticateScheme"/>.
+        /// Otherwise, this will fallback to <see cref="GetDefaultAuthenticateSchemeAsync"/> .
+        /// </summary>
+        /// <returns>The scheme that should be used to set <see cref="HttpContext.User"/>.</returns>
+        Task<AuthenticationScheme> GetAutomaticAuthenticateSchemeAsync();
+
+        /// <summary>
         /// Returns the scheme that will be used by default for <see cref="IAuthenticationService.AuthenticateAsync(HttpContext, string)"/>.
         /// This is typically specified via <see cref="AuthenticationOptions.DefaultAuthenticateScheme"/>.
         /// Otherwise, if only a single scheme exists, that will be used, if more than one exists, null will be returned.


### PR DESCRIPTION
Addresses https://github.com/aspnet/Security/issues/1287

New specific option that will UseAuthentication() will use to determine which scheme to authenticate

options.AutomaticAuthenticateScheme (falls back to DefaultAuthenticateScheme)

New flags to turn off fallback:

options.EnableDefaultFallback (turn off all fallback logic)
options.EnableDefaultSingleHandlerFallback (turns off just the single handler fallbacks)

cc @Tratcher @davidfowl 