### PR TITLE
Add boolean dispose flag in HttpRequestStreamReader/ResponseWriter (#540)

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,6 +3,7 @@
     <AspNetCoreVersion>2.1.0-*</AspNetCoreVersion>
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.1-*</InternalAspNetCoreSdkVersion>
+    <MoqVersion>4.7.49</MoqVersion>
     <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>

--- a/test/Microsoft.AspNetCore.WebUtilities.Tests/Microsoft.AspNetCore.WebUtilities.Tests.csproj
+++ b/test/Microsoft.AspNetCore.WebUtilities.Tests/Microsoft.AspNetCore.WebUtilities.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Remove nulling out fields in favor of a dispose boolean.
Fixes #540 