### PR TITLE
Lazy init FeatureReferences

### DIFF
--- a/samples/SampleApp/PooledHttpContext.cs
+++ b/samples/SampleApp/PooledHttpContext.cs
@@ -1,54 +1,92 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
 
 namespace SampleApp
 {
-    public class PooledHttpContext : DefaultHttpContext
+    public class PooledHttpContext : HttpContext
     {
-        DefaultHttpRequest _pooledHttpRequest;
-        DefaultHttpResponse _pooledHttpResponse;
+        private readonly DefaultHttpContext _context;
 
-        public PooledHttpContext(IFeatureCollection featureCollection) :
-            base(featureCollection)
+        public PooledHttpContext(IFeatureCollection featureCollection, Func<HttpRequest, FormFeature> formFeatureFactory)
         {
+            _context = new DefaultHttpContext(featureCollection, formFeatureFactory);
         }
 
-        protected override HttpRequest InitializeHttpRequest()
+        public void Initialize(IFeatureCollection featureCollection, Func<HttpRequest, FormFeature> formFeatureFactory)
         {
-            if (_pooledHttpRequest != null)
-            {
-                _pooledHttpRequest.Initialize(this);
-                return _pooledHttpRequest;
-            }
-
-            return new DefaultHttpRequest(this);
+            _context.Initialize(featureCollection, formFeatureFactory);
         }
 
-        protected override void UninitializeHttpRequest(HttpRequest instance)
+        public void Uninitialize()
         {
-            _pooledHttpRequest = instance as DefaultHttpRequest;
-            _pooledHttpRequest?.Uninitialize();
+            _context.Uninitialize();
         }
 
-        protected override HttpResponse InitializeHttpResponse()
-        {
-            if (_pooledHttpResponse != null)
-            {
-                _pooledHttpResponse.Initialize(this);
-                return _pooledHttpResponse;
-            }
+        public override IFeatureCollection Features => _context.Features;
 
-            return new DefaultHttpResponse(this);
+        public override HttpRequest Request => _context.Request;
+
+        public override HttpResponse Response => _context.Response;
+
+        public override ConnectionInfo Connection => _context.Connection;
+
+        public override WebSocketManager WebSockets => _context.WebSockets;
+
+        /// <summary>
+        /// This is obsolete and will be removed in a future version. 
+        /// The recommended alternative is to use Microsoft.AspNetCore.Authentication.AuthenticationHttpContextExtensions.
+        /// See https://go.microsoft.com/fwlink/?linkid=845470.
+        /// </summary>
+        [Obsolete("This is obsolete and will be removed in a future version. The recommended alternative is to use Microsoft.AspNetCore.Authentication.AuthenticationHttpContextExtensions. See https://go.microsoft.com/fwlink/?linkid=845470.")]
+        public override AuthenticationManager Authentication => _context.Authentication;
+
+        public override ClaimsPrincipal User
+        {
+            get => _context.User;
+            set => _context.User = value;
         }
 
-        protected override void UninitializeHttpResponse(HttpResponse instance)
+        public override IDictionary<object, object> Items
         {
-            _pooledHttpResponse = instance as DefaultHttpResponse;
-            _pooledHttpResponse?.Uninitialize();
+            get => _context.Items;
+            set => _context.Items = value;
+        }
+
+        public override IServiceProvider RequestServices
+        {
+            get => _context.RequestServices;
+            set => _context.RequestServices = value;
+        }
+
+        public override CancellationToken RequestAborted
+        {
+            get => _context.RequestAborted;
+            set => _context.RequestAborted = value;
+        }
+
+        public override string TraceIdentifier
+        {
+            get => _context.TraceIdentifier;
+            set => _context.TraceIdentifier = value;
+        }
+
+        public override ISession Session
+        {
+            get => _context.Session;
+            set => _context.Session = value;
+        }
+
+        public override void Abort()
+        {
+            _context.Abort();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Http.Features/FeatureReferences.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/FeatureReferences.cs
@@ -10,9 +10,16 @@ namespace Microsoft.AspNetCore.Http.Features
     {
         public FeatureReferences(IFeatureCollection collection)
         {
+            Revision = collection.Revision;
             Collection = collection;
             Cache = default(TCache);
-            Revision = collection.Revision;
+        }
+
+        public FeatureReferences(IFeatureCollection collection, int revision)
+        {
+            Revision = revision;
+            Collection = collection;
+            Cache = default(TCache);
         }
 
         public IFeatureCollection Collection { get; private set; }
@@ -61,6 +68,19 @@ namespace Microsoft.AspNetCore.Http.Features
             }
 
             return cached ?? UpdateCached(ref cached, state, factory, revision, flush);
+        }
+
+        public int GetRevisionAndValidateCache()
+        {
+            var revision = Collection.Revision;
+            if (Revision != revision)
+            {
+                Revision = revision;
+                // Collection detected as changed, clear cache
+                Cache = default(TCache);
+            }
+
+            return revision;
         }
 
         // Update and cache clearing logic, when the fast-path in Fetch isn't applicable

--- a/src/Microsoft.AspNetCore.Http/HttpContextFactory.cs
+++ b/src/Microsoft.AspNetCore.Http/HttpContextFactory.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Http
     public class HttpContextFactory : IHttpContextFactory
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly FormOptions _formOptions;
+        private readonly Func<HttpRequest, FormFeature> _formFeatureFactory;
 
         public HttpContextFactory(IOptions<FormOptions> formOptions)
             : this(formOptions, httpContextAccessor: null)
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException(nameof(formOptions));
             }
 
-            _formOptions = formOptions.Value;
+            _formFeatureFactory = request => new FormFeature(request, formOptions.Value);
             _httpContextAccessor = httpContextAccessor;
         }
 
@@ -35,14 +35,11 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException(nameof(featureCollection));
             }
 
-            var httpContext = new DefaultHttpContext(featureCollection);
+            var httpContext = new DefaultHttpContext(featureCollection, _formFeatureFactory);
             if (_httpContextAccessor != null)
             {
                 _httpContextAccessor.HttpContext = httpContext;
             }
-
-            var formFeature = new FormFeature(httpContext.Request, _formOptions);
-            featureCollection.Set<IFormFeature>(formFeature);
 
             return httpContext;
         }

--- a/src/Microsoft.AspNetCore.Http/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.Http/breakingchanges.netcore.json
@@ -8,5 +8,65 @@
       "TypeId": "public class Microsoft.AspNetCore.Http.HttpContextFactory : Microsoft.AspNetCore.Http.IHttpContextFactory",
       "MemberId": "public .ctor(Microsoft.Extensions.ObjectPool.ObjectPoolProvider poolProvider, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Http.Features.FormOptions> formOptions, Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor)",
       "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual Microsoft.AspNetCore.Http.Authentication.AuthenticationManager InitializeAuthenticationManager()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual Microsoft.AspNetCore.Http.ConnectionInfo InitializeConnectionInfo()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual Microsoft.AspNetCore.Http.HttpRequest InitializeHttpRequest()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual Microsoft.AspNetCore.Http.HttpResponse InitializeHttpResponse()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual Microsoft.AspNetCore.Http.WebSocketManager InitializeWebSocketManager()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual System.Void UninitializeAuthenticationManager(Microsoft.AspNetCore.Http.Authentication.AuthenticationManager instance)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual System.Void UninitializeConnectionInfo(Microsoft.AspNetCore.Http.ConnectionInfo instance)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual System.Void UninitializeHttpRequest(Microsoft.AspNetCore.Http.HttpRequest instance)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual System.Void UninitializeHttpResponse(Microsoft.AspNetCore.Http.HttpResponse instance)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "protected virtual System.Void UninitializeWebSocketManager(Microsoft.AspNetCore.Http.WebSocketManager instance)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "public virtual System.Void Initialize(Microsoft.AspNetCore.Http.Features.IFeatureCollection features)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Http.DefaultHttpContext : Microsoft.AspNetCore.Http.HttpContext",
+      "MemberId": "public virtual System.Void Uninitialize()",
+      "Kind": "Removal"
     }
   ]

--- a/test/Microsoft.AspNetCore.Http.Tests/DefaultHttpContextTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/DefaultHttpContextTests.cs
@@ -152,13 +152,17 @@ namespace Microsoft.AspNetCore.Http
         [Fact]
         public void UpdateFeatures_ClearsCachedFeatures()
         {
+            Func<HttpRequest, FormFeature> formFeatureFactory = request => new FormFeature(request);
+
             var features = new FeatureCollection();
             features.Set<IHttpRequestFeature>(new HttpRequestFeature());
             features.Set<IHttpResponseFeature>(new HttpResponseFeature());
             features.Set<IHttpWebSocketFeature>(new TestHttpWebSocketFeature());
 
             // featurecollection is set. all cached interfaces are null.
-            var context = new DefaultHttpContext(features);
+            var context = new DefaultHttpContext(features, formFeatureFactory);
+            // Trigger initalization
+            Assert.NotNull(context.Request);
             TestAllCachedFeaturesAreNull(context, features);
             Assert.Equal(3, features.Count());
 
@@ -178,7 +182,9 @@ namespace Microsoft.AspNetCore.Http
             newFeatures.Set<IHttpWebSocketFeature>(new TestHttpWebSocketFeature());
 
             // featurecollection is set to newFeatures. all cached interfaces are null.
-            context.Initialize(newFeatures);
+            context.Initialize(newFeatures, formFeatureFactory);
+            // Trigger initalization
+            Assert.NotNull(context.Request);
             TestAllCachedFeaturesAreNull(context, newFeatures);
             Assert.Equal(3, newFeatures.Count());
 


### PR DESCRIPTION
Follow up on https://github.com/aspnet/HttpAbstractions/pull/814 "Improve DefaultHttpXxx default paths"

Fixes https://github.com/aspnet/HttpAbstractions/issues/924 "FeatureCache is over-checked and over-reset"

The Context feature cache is checked and initializes the Response and Request caches at the point one is accessed, so the version check via interface (and sum through collection counts) is shared; and the FeatureReferences structs are only initialized once.

It cuts the version checks from 7 to 5; and the cache initialization to 2x Context, 1x Request, 1x Response, so down 2.

Pre
![](https://aoa.blob.core.windows.net/aspnet/feature-cache.png)

Post
![](https://aoa.blob.core.windows.net/aspnet/feature-cache-2.png)

The early init of the FormFeature triggered the access of the HttpRequest and caused initalization; so I had to move that to be on demand - so it also resolves:

Fixes https://github.com/aspnet/HttpAbstractions/issues/677 "FormFeature allocates when unused"
Fixes https://github.com/aspnet/HttpAbstractions/issues/880 "Don't allocate the FormFeature eagerly per request"

Also

Sealed and made concrete the `DefaultHttpRequest` and `DefaultHttpResponse` class/references for devirtualization and made their initialization/uninitialization simpler.

Someone can always inherit from `HttpContext`/`HttpRequest`/`HttpResponse` if they want a non-Default. 

However it doesn't preclude alternative uses. As an example, reimplemented the `PooledHttpContext` sample by composing with `DefaultHttpContext` rather than via inheritance.

/cc @davidfowl @muratg @vancem @Tratcher @HaoK 