### PR TITLE
Add Strict-Transport-Security header name

### DIFF
--- a/src/Microsoft.Net.Http.Headers/HeaderNames.cs
+++ b/src/Microsoft.Net.Http.Headers/HeaderNames.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Net.Http.Headers
         public const string RetryAfter = "Retry-After";
         public const string Server = "Server";
         public const string SetCookie = "Set-Cookie";
+        public const string StrictTransportSecurity = "Strict-Transport-Security";
         public const string TE = "TE";
         public const string Trailer = "Trailer";
         public const string TransferEncoding = "Transfer-Encoding";


### PR DESCRIPTION
To be eventually used by the https and hsts middleware (and other places that need it).