### PR TITLE
Change MiddlewareFactory to type activate IMiddleware as a fallback

### DIFF
--- a/src/Microsoft.AspNetCore.Http/MiddlewareFactory.cs
+++ b/src/Microsoft.AspNetCore.Http/MiddlewareFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Http
 
         public IMiddleware Create(Type middlewareType)
         {
-            return _serviceProvider.GetRequiredService(middlewareType) as IMiddleware;
+            return ActivatorUtilities.GetServiceOrCreateInstance(_serviceProvider, middlewareType) as IMiddleware;
         }
 
         public void Release(IMiddleware middleware)

--- a/test/Microsoft.AspNetCore.Http.Abstractions.Tests/UseMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Http.Abstractions.Tests/UseMiddlewareTest.cs
@@ -232,6 +232,23 @@ namespace Microsoft.AspNetCore.Http
             Assert.Same(middlewareFactory.Created, middlewareFactory.Released);
         }
 
+        [Fact]
+        public async Task UseMiddlewareWithIMiddlewareAndMiddlewareFactoryTypeActivates()
+        {
+            var mockServiceProvider = new DummyServiceProvider();
+            var builder = new ApplicationBuilder(mockServiceProvider);
+            builder.UseMiddleware(typeof(Middleware));
+            var app = builder.Build();
+            var context = new DefaultHttpContext();
+            var sp = new DummyServiceProvider();
+            var middlewareFactory = new MiddlewareFactory(sp);
+            sp.AddService(typeof(IMiddlewareFactory), middlewareFactory);
+            context.RequestServices = sp;
+            await app(context);
+            Assert.True(Assert.IsType<bool>(context.Items["before"]));
+            Assert.True(Assert.IsType<bool>(context.Items["after"]));
+        }
+
         public class Middleware : IMiddleware
         {
             public async Task InvokeAsync(HttpContext context, RequestDelegate next)


### PR DESCRIPTION
- This eases the transition and learning when you discover there's
an interface for middleware.
- Inspired by https://stackoverflow.com/questions/48394756/no-service-for-type-has-been-registered/
/cc @guardrex 