### PR TITLE
Revert "Change MiddlewareFactory to type activate IMiddleware as a fa…

### DIFF
--- a/src/Microsoft.AspNetCore.Http/MiddlewareFactory.cs
+++ b/src/Microsoft.AspNetCore.Http/MiddlewareFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Http
 
         public IMiddleware Create(Type middlewareType)
         {
-            return ActivatorUtilities.GetServiceOrCreateInstance(_serviceProvider, middlewareType) as IMiddleware;
+            return _serviceProvider.GetRequiredService(middlewareType) as IMiddleware;
         }
 
         public void Release(IMiddleware middleware)

--- a/test/Microsoft.AspNetCore.Http.Abstractions.Tests/UseMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Http.Abstractions.Tests/UseMiddlewareTest.cs
@@ -232,23 +232,6 @@ namespace Microsoft.AspNetCore.Http
             Assert.Same(middlewareFactory.Created, middlewareFactory.Released);
         }
 
-        [Fact]
-        public async Task UseMiddlewareWithIMiddlewareAndMiddlewareFactoryTypeActivates()
-        {
-            var mockServiceProvider = new DummyServiceProvider();
-            var builder = new ApplicationBuilder(mockServiceProvider);
-            builder.UseMiddleware(typeof(Middleware));
-            var app = builder.Build();
-            var context = new DefaultHttpContext();
-            var sp = new DummyServiceProvider();
-            var middlewareFactory = new MiddlewareFactory(sp);
-            sp.AddService(typeof(IMiddlewareFactory), middlewareFactory);
-            context.RequestServices = sp;
-            await app(context);
-            Assert.True(Assert.IsType<bool>(context.Items["before"]));
-            Assert.True(Assert.IsType<bool>(context.Items["after"]));
-        }
-
         public class Middleware : IMiddleware
         {
             public async Task InvokeAsync(HttpContext context, RequestDelegate next)


### PR DESCRIPTION
…llback (#988)"

This reverts commit 44d5bf074fd72886f2a6880b8cf27ff8826399cf.

To make this work well, we need to have 2 implementations of IMiddlewareFactory, a services based one and a non services based one. The problem is that for disposal, the container needs to do the right thing in the services implementation and the non services based implementation needs to dispose manually.

The hybrid approach requires that we can determine if a particular middleware instance came from the container or from the was activated by the activator utilities. In order to avoid that book keeping, I'm just reverting this for now.
