### PR TITLE
Reduce FeatureReference checking, lazy init FormFeature

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Features/FeatureReferences.cs
+++ b/src/Microsoft.AspNetCore.Http.Features/FeatureReferences.cs
@@ -15,6 +15,13 @@ namespace Microsoft.AspNetCore.Http.Features
             Revision = collection.Revision;
         }
 
+        public FeatureReferences(IFeatureCollection collection, int revision)
+        {
+            Collection = collection;
+            Cache = default(TCache);
+            Revision = revision;
+        }
+
         public IFeatureCollection Collection { get; private set; }
         public int Revision { get; private set; }
 

--- a/src/Microsoft.AspNetCore.Http/Features/FormFeature.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/FormFeature.cs
@@ -15,8 +15,6 @@ namespace Microsoft.AspNetCore.Http.Features
 {
     public class FormFeature : IFormFeature
     {
-        private static readonly FormOptions DefaultFormOptions = new FormOptions();
-
         private readonly HttpRequest _request;
         private readonly FormOptions _options;
         private Task<IFormCollection> _parsedFormTask;
@@ -32,7 +30,7 @@ namespace Microsoft.AspNetCore.Http.Features
             Form = form;
         }
         public FormFeature(HttpRequest request)
-            : this(request, DefaultFormOptions)
+            : this(request, FormOptions.Default)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Http/Features/FormOptions.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/FormOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Http.Features
 {
     public class FormOptions
     {
-        public static readonly FormOptions Default = new FormOptions();
+        internal static readonly FormOptions Default = new FormOptions();
 
         public const int DefaultMemoryBufferThreshold = 1024 * 64;
         public const int DefaultBufferBodyLengthLimit = 1024 * 1024 * 128;

--- a/src/Microsoft.AspNetCore.Http/Features/FormOptions.cs
+++ b/src/Microsoft.AspNetCore.Http/Features/FormOptions.cs
@@ -8,6 +8,8 @@ namespace Microsoft.AspNetCore.Http.Features
 {
     public class FormOptions
     {
+        public static readonly FormOptions Default = new FormOptions();
+
         public const int DefaultMemoryBufferThreshold = 1024 * 64;
         public const int DefaultBufferBodyLengthLimit = 1024 * 1024 * 128;
         public const int DefaultMultipartBoundaryLengthLimit = 128;

--- a/src/Microsoft.AspNetCore.Http/HttpContextFactory.cs
+++ b/src/Microsoft.AspNetCore.Http/HttpContextFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException(nameof(formOptions));
             }
 
-            _formOptions = formOptions.Value;
+            _formOptions = formOptions.Value ?? FormOptions.Default;
             _httpContextAccessor = httpContextAccessor;
         }
 
@@ -35,14 +35,11 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException(nameof(featureCollection));
             }
 
-            var httpContext = new DefaultHttpContext(featureCollection);
+            var httpContext = new DefaultHttpContext(featureCollection, _formOptions);
             if (_httpContextAccessor != null)
             {
                 _httpContextAccessor.HttpContext = httpContext;
             }
-
-            var formFeature = new FormFeature(httpContext.Request, _formOptions);
-            featureCollection.Set<IFormFeature>(formFeature);
 
             return httpContext;
         }

--- a/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpRequest.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpRequest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Http.Internal
         // Lambdas hoisted to static readonly fields to improve inlining https://github.com/dotnet/roslyn/issues/13624
         private readonly static Func<IFeatureCollection, IHttpRequestFeature> _nullRequestFeature = f => null;
         private readonly static Func<IFeatureCollection, IQueryFeature> _newQueryFeature = f => new QueryFeature(f);
-        private readonly static Func<(HttpRequest request, FormOptions options), IFormFeature> _newFormFeature = (r) => new FormFeature(r.request, r.options ?? FormOptions.Default);
+        private readonly static Func<HttpRequest, FormOptions, IFormFeature> _newFormFeature = (r, o) => new FormFeature(r, o ?? FormOptions.Default);
         private readonly static Func<IFeatureCollection, IRequestCookiesFeature> _newRequestCookiesFeature = f => new RequestCookiesFeature(f);
 
         private FormOptions _formOptions;
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Http.Internal
             _features.Fetch(ref _features.Cache.Query, _newQueryFeature);
 
         private IFormFeature FormFeature =>
-            _features.Fetch(ref _features.Cache.Form, (this, _formOptions), _newFormFeature);
+            _features.Fetch(ref _features.Cache.Form, this, _formOptions, _newFormFeature);
 
         private IRequestCookiesFeature RequestCookiesFeature =>
             _features.Fetch(ref _features.Cache.Cookies, _newRequestCookiesFeature);

--- a/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpResponse.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/DefaultHttpResponse.cs
@@ -19,14 +19,25 @@ namespace Microsoft.AspNetCore.Http.Internal
         private FeatureReferences<FeatureInterfaces> _features;
 
         public DefaultHttpResponse(HttpContext context)
+            : this(context, context.Features.Revision, context.Features)
         {
-            Initialize(context);
+        }
+
+        internal DefaultHttpResponse(HttpContext context, int revision, IFeatureCollection features)
+        {
+            _context = context;
+            Initialize(features, revision);
         }
 
         public virtual void Initialize(HttpContext context)
         {
             _context = context;
-            _features = new FeatureReferences<FeatureInterfaces>(context.Features);
+            Initialize(context.Features, context.Features.Revision);
+        }
+
+        private void Initialize(IFeatureCollection features, int revision)
+        {
+            _features = new FeatureReferences<FeatureInterfaces>(features, revision);
         }
 
         public virtual void Uninitialize()

--- a/test/Microsoft.AspNetCore.Http.Tests/DefaultHttpContextTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/DefaultHttpContextTests.cs
@@ -159,6 +159,8 @@ namespace Microsoft.AspNetCore.Http
 
             // featurecollection is set. all cached interfaces are null.
             var context = new DefaultHttpContext(features);
+            // Trigger initalization
+            Assert.NotNull(context.Request);
             TestAllCachedFeaturesAreNull(context, features);
             Assert.Equal(3, features.Count());
 
@@ -178,7 +180,9 @@ namespace Microsoft.AspNetCore.Http
             newFeatures.Set<IHttpWebSocketFeature>(new TestHttpWebSocketFeature());
 
             // featurecollection is set to newFeatures. all cached interfaces are null.
-            context.Initialize(newFeatures);
+            context.Initialize(newFeatures, FormOptions.Default);
+            // Trigger initalization
+            Assert.NotNull(context.Request);
             TestAllCachedFeaturesAreNull(context, newFeatures);
             Assert.Equal(3, newFeatures.Count());
 

--- a/test/Microsoft.AspNetCore.Http.Tests/DefaultHttpContextTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Tests/DefaultHttpContextTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Http
             newFeatures.Set<IHttpWebSocketFeature>(new TestHttpWebSocketFeature());
 
             // featurecollection is set to newFeatures. all cached interfaces are null.
-            context.Initialize(newFeatures, FormOptions.Default);
+            context.Initialize(newFeatures);
             // Trigger initalization
             Assert.NotNull(context.Request);
             TestAllCachedFeaturesAreNull(context, newFeatures);


### PR DESCRIPTION
Update to https://github.com/aspnet/HttpAbstractions/pull/925

Resolves #924 "FeatureCache is over-checked and over-reset"
Resolves #677 "FormFeature allocates when unused"
Resolves #880 "Don't allocate the FormFeature eagerly per request"

/cc @davidfowl 