### PR TITLE
Commas in doc comments

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/HeaderDictionaryExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Http
         }
 
         /// <summary>
-        /// Quotes any values containing comas, and then coma joins all of the values with any existing values.
+        /// Quotes any values containing commas, and then comma joins all of the values with any existing values.
         /// </summary>
         /// <param name="headers">The <see cref="IHeaderDictionary"/> to use.</param>
         /// <param name="key">The header name.</param>
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Http
         }
 
         /// <summary>
-        /// Quotes any values containing comas, and then coma joins all of the values.
+        /// Quotes any values containing commas, and then comma joins all of the values.
         /// </summary>
         /// <param name="headers">The <see cref="IHeaderDictionary"/> to use.</param>
         /// <param name="key">The header name.</param>

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Internal/ParsingHelpers.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Internal/ParsingHelpers.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Http.Internal
             }
         }
 
-        // Quote items that contain comas and are not already quoted.
+        // Quote items that contain commas and are not already quoted.
         private static string QuoteIfNeeded(string value)
         {
             if (!string.IsNullOrEmpty(value) &&


### PR DESCRIPTION
Noticed this while using the APIs. We separate values with `,` not with unconsciousness.