### PR TITLE
[NoMerge] React to StringValues

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Extensions/HeaderDictionaryExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Http
         /// <returns>the associated values from the collection separated into individual values, or StringValues.Empty if the key is not present.</returns>
         public static string[] GetCommaSeparatedValues(this IHeaderDictionary headers, string key)
         {
-            return ParsingHelpers.GetHeaderSplit(headers, key).ToArray();
+            return ParsingHelpers.GetHeaderSplit(headers, key);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Http.Abstractions/Internal/ParsingHelpers.cs
+++ b/src/Microsoft.AspNetCore.Http.Abstractions/Internal/ParsingHelpers.cs
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Http.Internal
                 throw new ArgumentNullException(nameof(key));
             }
 
-            if (values.Count == 0)
+            if (values.IsNull)
             {
                 return;
             }

--- a/src/Microsoft.AspNetCore.Http/HeaderDictionary.cs
+++ b/src/Microsoft.AspNetCore.Http/HeaderDictionary.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Http
                 }
                 ThrowIfReadOnly();
 
-                if (StringValues.IsNullOrEmpty(value))
+                if (value.ToString().Length == 0)
                 {
                     Store?.Remove(key);
                 }
@@ -177,8 +177,11 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException("The key is null");
             }
             ThrowIfReadOnly();
-            EnsureStore(1);
-            Store.Add(item.Key, item.Value);
+            if (item.Value.ToString().Length > 0)
+            {
+                EnsureStore(1);
+                Store.Add(item.Key, item.Value);
+            }
         }
 
         /// <summary>
@@ -193,8 +196,11 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException(nameof(key));
             }
             ThrowIfReadOnly();
-            EnsureStore(1);
-            Store.Add(key, value);
+            if (value.ToString().Length > 0)
+            {
+                EnsureStore(1);
+                Store.Add(key, value);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.WebUtilities/KeyValueAccumulator.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/KeyValueAccumulator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             StringValues values;
             if (_accumulator.TryGetValue(key, out values))
             {
-                if (values.Count == 0)
+                if (values.IsNull)
                 {
                     // Marker entry for this key to indicate entry already in expanding list dictionary
                     _expandingAccumulator[key].Add(value);


### PR DESCRIPTION
Isn't it only `HeaderDictionary` that needs the change to not add `null`s to the dictionary in the `IDictionary` path as it does in the `IHeaderDictionary` path?

Also needs https://github.com/aspnet/Common/pull/330

/cc @Tratcher  @ryanbrandenburg @dougbu @rynowak @halter73 