### PR TITLE
Fix FileBufferingReadStream not working with StreamContent

### DIFF
--- a/src/Microsoft.AspNetCore.Http/Internal/BufferingHelper.cs
+++ b/src/Microsoft.AspNetCore.Http/Internal/BufferingHelper.cs
@@ -48,7 +48,8 @@ namespace Microsoft.AspNetCore.Http.Internal
             var body = request.Body;
             if (!body.CanSeek)
             {
-                var fileStream = new FileBufferingReadStream(body, bufferThreshold, bufferLimit, _getTempDirectory);
+                var fileStream = new FileBufferingReadStream(body, request.ContentLength, bufferThreshold, bufferLimit, _getTempDirectory);
+                
                 request.Body = fileStream;
                 request.HttpContext.Response.RegisterForDispose(fileStream);
             }


### PR DESCRIPTION
Address dotnet/corefx#31866

Before FileBufferingReadStream is first read, it's length is not properly set. Before StreamContent is read, it's inner stream length is used to compute ContentLength. When they get together in HttpClient, an http request with misleading `Content-Length: 0` is produced.

This PR introduces `_innerLength` to return the length of inner stream before FileBufferingReadStream is first read.