### PR TITLE
Fast-path async in HttpResponseStreamWriter

### DIFF
--- a/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
@@ -231,12 +231,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 return GetObjectDisposedTask();
             }
 
-            if (value == null)
-            {
-                return Task.CompletedTask;
-            }
-
-            var count = value.Length;
+            var count = value?.Length ?? 0;
             if (count == 0)
             {
                 return Task.CompletedTask;

--- a/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             var count = value.Length;
 
             Debug.Assert(count > 0);
-            Debug.Assert(_charBufferSize - _charBufferCount > count);
+            Debug.Assert(_charBufferSize - _charBufferCount < count);
 
             var index = 0;
             while (count > 0)

--- a/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
@@ -231,8 +231,13 @@ namespace Microsoft.AspNetCore.WebUtilities
                 return GetObjectDisposedTask();
             }
 
+            if (value == null)
+            {
+                return Task.CompletedTask;
+            }
+
             var count = value.Length;
-            if (value == null || count == 0)
+            if (count == 0)
             {
                 return Task.CompletedTask;
             }

--- a/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -150,33 +152,65 @@ namespace Microsoft.AspNetCore.WebUtilities
             }
         }
 
-        public override async Task WriteAsync(char value)
+        public override Task WriteAsync(char value)
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+                return GetObjectDisposedTask();
             }
 
             if (_charBufferCount == _charBufferSize)
             {
-                await FlushInternalAsync(flushEncoder: false);
+                return WriteAsyncAwaited(value);
             }
+            else
+            {
+                // Enough room in buffer, no need to go async
+                _charBuffer[_charBufferCount] = value;
+                _charBufferCount++;
+                return Task.CompletedTask;
+            }
+        }
+
+        private async Task WriteAsyncAwaited(char value)
+        {
+            Debug.Assert(_charBufferCount == _charBufferSize);
+
+            await FlushInternalAsync(flushEncoder: false);
 
             _charBuffer[_charBufferCount] = value;
             _charBufferCount++;
         }
 
-        public override async Task WriteAsync(char[] values, int index, int count)
+        public override Task WriteAsync(char[] values, int index, int count)
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+                return GetObjectDisposedTask();
             }
 
-            if (values == null)
+            if (values == null || count == 0)
             {
-                return;
+                return Task.CompletedTask;
             }
+
+            var remaining = _charBufferSize - _charBufferCount;
+            if (remaining >= count)
+            {
+                // Enough room in buffer, no need to go async
+                CopyToCharBuffer(values, ref index, ref count);
+                return Task.CompletedTask;
+            }
+            else
+            {
+                return WriteAsyncAwaited(values, index, count);
+            }
+        }
+
+        private async Task WriteAsyncAwaited(char[] values, int index, int count)
+        {
+            Debug.Assert(count > 0);
+            Debug.Assert(_charBufferSize - _charBufferCount > count);
 
             while (count > 0)
             {
@@ -186,22 +220,43 @@ namespace Microsoft.AspNetCore.WebUtilities
                 }
 
                 CopyToCharBuffer(values, ref index, ref count);
+                Debug.Assert(count == 0);
             }
         }
 
-        public override async Task WriteAsync(string value)
+        public override Task WriteAsync(string value)
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
-            }
-
-            if (value == null)
-            {
-                return;
+                return GetObjectDisposedTask();
             }
 
             var count = value.Length;
+            if (value == null || count == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            var remaining = _charBufferSize - _charBufferCount;
+            if (remaining >= count)
+            {
+                // Enough room in buffer, no need to go async
+                CopyToCharBuffer(value);
+                return Task.CompletedTask;
+            }
+            else
+            {
+                return WriteAsyncAwaited(value);
+            }
+        }
+
+        private async Task WriteAsyncAwaited(string value)
+        {
+            var count = value.Length;
+
+            Debug.Assert(count > 0);
+            Debug.Assert(_charBufferSize - _charBufferCount > count);
+
             var index = 0;
             while (count > 0)
             {
@@ -231,7 +286,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+                return GetObjectDisposedTask();
             }
 
             return FlushInternalAsync(flushEncoder: true);
@@ -306,6 +361,19 @@ namespace Microsoft.AspNetCore.WebUtilities
             }
         }
 
+        private void CopyToCharBuffer(string value)
+        {
+            Debug.Assert(_charBufferSize - _charBufferCount >= value.Length);
+
+            value.CopyTo(
+                sourceIndex: 0,
+                destination: _charBuffer,
+                destinationIndex: _charBufferCount,
+                count: value.Length);
+
+            _charBufferCount += value.Length;
+        }
+
         private void CopyToCharBuffer(string value, ref int index, ref int count)
         {
             var remaining = Math.Min(_charBufferSize - _charBufferCount, count);
@@ -335,6 +403,12 @@ namespace Microsoft.AspNetCore.WebUtilities
             _charBufferCount += remaining;
             index += remaining;
             count -= remaining;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Task GetObjectDisposedTask()
+        {
+            return Task.FromException(new ObjectDisposedException(nameof(HttpResponseStreamWriter)));
         }
     }
 }


### PR DESCRIPTION
The ratio of non-async paths in `WriteAsync` of `HttpResponseStreamWriter` to `async` paths (including `FlushAsync`) for the RazorRendering benchmarkapp https://github.com/aspnet/Mvc/pull/8366

For 1 request in the currently its 8774 non-async to 12 async.

![image](https://user-images.githubusercontent.com/1142958/44941463-da5c1400-ad95-11e8-9286-20df30cc7343.png)

This adds a fast-path to skip the async statemahchine creation for when no `FlushAsync` takes place.

It also means it can be detected upstream in MVC and allow more fast-paths to flow

/cc @davidfowl @rynowak 