### PR TITLE
Add support for HttpCookie expires date format

### DIFF
--- a/src/Microsoft.Net.Http.Headers/HttpRuleParser.cs
+++ b/src/Microsoft.Net.Http.Headers/HttpRuleParser.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Net.Http.Headers
             "ddd, d MMM yyyy H:m:s", // RFC 5322 no zone
             "d MMM yyyy H:m:s zzz", // RFC 5322 no day-of-week
             "d MMM yyyy H:m:s", // RFC 5322 no day-of-week, no zone
+
+            "ddd, dd'-'MMM'-'yyyy HH':'mm':'ss 'GMT'", // HttpCookie format from http://referencesource.microsoft.com/#System.Web/httpserverutility.cs,1526
         };
 
         internal const char CR = '\r';


### PR DESCRIPTION
The format generated by System.Web.HttpCookie when formated is non-standard, a mix between RFC1123 and RFC850 (At least as of .NET Framework 4.6.1)

The exact format string used is `"ddd, dd-MMM-yyyy HH':'mm':'ss 'GMT'"` as seen [here](http://referencesource.microsoft.com/#System.Web/httpserverutility.cs,1526)

This doesn't quite match RFC1123 which is `"ddd, d MMM yyyy H:m:s 'GMT'"` as it uses dashes between the day, month, and year instead of spaces, but doesn't quite match RFC850 which is `"dddd, d'-'MMM'-'yy H:m:s 'GMT'"` as it uses a short day of the week instead of a longer form.

This change allows the SetCookieHeaderValue to properly parse a response from the an API using the older System.Web.HttpCookie class to generate a HTTP response.
