### PR TITLE
Do not throw a null reference from request.GetDisplayUrl()

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
+++ b/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
@@ -195,16 +195,16 @@ namespace Microsoft.AspNetCore.Http.Extensions
         /// <returns></returns>
         public static string GetDisplayUrl(this HttpRequest request)
         {
-            var host = request.Host.Value;
-            var pathBase = request.PathBase.Value;
-            var path = request.Path.Value;
-            var queryString = request.QueryString.Value;
+            var host = request.Host.Value ?? "";
+            var pathBase = request.PathBase.Value ?? "";
+            var path = request.Path.Value ?? "";
+            var queryString = request.QueryString.Value ?? "";
 
             // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
-            var length = request.Scheme?.Length ?? 0 + SchemeDelimiter.Length + host?.Length ?? 0
-                + pathBase?.Length ?? 0 + path?.Length ?? 0 + queryString?.Length ?? 0;
+            var length = request.Scheme.Length + SchemeDelimiter.Length + host.Length
+                + pathBase.Length + path.Length + queryString.Length;
 
-            return new StringBuilder(length)
+            return new StringBuilder()
                 .Append(request.Scheme)
                 .Append(SchemeDelimiter)
                 .Append(host)

--- a/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
+++ b/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
@@ -195,17 +195,18 @@ namespace Microsoft.AspNetCore.Http.Extensions
         /// <returns></returns>
         public static string GetDisplayUrl(this HttpRequest request)
         {
+            var scheme = request.Scheme ?? "";            
             var host = request.Host.Value ?? "";
             var pathBase = request.PathBase.Value ?? "";
             var path = request.Path.Value ?? "";
             var queryString = request.QueryString.Value ?? "";
 
             // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
-            var length = request.Scheme.Length + SchemeDelimiter.Length + host.Length
+            var length = scheme.Length + SchemeDelimiter.Length + host.Length
                 + pathBase.Length + path.Length + queryString.Length;
 
             return new StringBuilder(length)
-                .Append(request.Scheme)
+                .Append(scheme)
                 .Append(SchemeDelimiter)
                 .Append(host)
                 .Append(pathBase)

--- a/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
+++ b/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
@@ -201,8 +201,8 @@ namespace Microsoft.AspNetCore.Http.Extensions
             var queryString = request.QueryString.Value;
 
             // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
-            var length = request.Scheme.Length + SchemeDelimiter.Length + host.Length
-                + pathBase.Length + path.Length + queryString.Length;
+            var length = request.Scheme?.Length ?? 0 + SchemeDelimiter.Length + host?.Length ?? 0
+                + pathBase?.Length ?? 0 + path?.Length ?? 0 + queryString?.Length ?? 0;
 
             return new StringBuilder(length)
                 .Append(request.Scheme)

--- a/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
+++ b/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
             var length = request.Scheme.Length + SchemeDelimiter.Length + host.Length
                 + pathBase.Length + path.Length + queryString.Length;
 
-            return new StringBuilder()
+            return new StringBuilder(length)
                 .Append(request.Scheme)
                 .Append(SchemeDelimiter)
                 .Append(host)

--- a/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
+++ b/src/Microsoft.AspNetCore.Http.Extensions/UriHelper.cs
@@ -195,11 +195,11 @@ namespace Microsoft.AspNetCore.Http.Extensions
         /// <returns></returns>
         public static string GetDisplayUrl(this HttpRequest request)
         {
-            var scheme = request.Scheme ?? "";            
-            var host = request.Host.Value ?? "";
-            var pathBase = request.PathBase.Value ?? "";
-            var path = request.Path.Value ?? "";
-            var queryString = request.QueryString.Value ?? "";
+            var scheme = request.Scheme ?? string.Empty;            
+            var host = request.Host.Value ?? string.Empty;
+            var pathBase = request.PathBase.Value ?? string.Empty;
+            var path = request.Path.Value ?? string.Empty;
+            var queryString = request.QueryString.Value ?? string.Empty;
 
             // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
             var length = scheme.Length + SchemeDelimiter.Length + host.Length

--- a/test/Microsoft.AspNetCore.Http.Extensions.Tests/UriHelperTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Extensions.Tests/UriHelperTests.cs
@@ -55,17 +55,19 @@ namespace Microsoft.AspNetCore.Http.Extensions
             Assert.Equal("http://my.xn--host-cpd:80/un%3Fescaped/base/un%3Fescaped?name=val%23ue", request.GetEncodedUrl());
         }
 
-        [Fact]
-        public void GetDisplayUrlFromRequest()
+        [Theory]
+        [InlineData("/un?escaped/base")]
+        [InlineData(null)]
+        public void GetDisplayUrlFromRequest(string pathBase)
         {
             var request = new DefaultHttpContext().Request;
             request.Scheme = "http";
             request.Host = new HostString("my.HoΨst:80");
-            request.PathBase = new PathString("/un?escaped/base");
+            request.PathBase = new PathString(pathBase);
             request.Path = new PathString("/un?escaped");
             request.QueryString = new QueryString("?name=val%23ue");
 
-            Assert.Equal("http://my.hoψst:80/un?escaped/base/un?escaped?name=val%23ue", request.GetDisplayUrl());
+            Assert.Equal("http://my.hoψst:80" + pathBase + "/un?escaped?name=val%23ue", request.GetDisplayUrl());
         }
 
         [Theory]


### PR DESCRIPTION
This is based on a customer bug. It is possible for a middleware and other participants in the request pipeline to modify things like properties of the request (i.e. `PathBase`).
Then, when `request.GetDisplayUrl()` is called on the same request, there are no null checks on the request properties needed to compute the URL, which in extreme cases causes it to throw an unhandled exception.

One example of running into this, is a following middleware.

```
            app.Use((context, next) =>
            {
                context.Request.PathBase = new PathString(context.Request.Headers["x-forwarded-prefix"]);
                return next();
            });
```

When issuing a request without `x-forwarded-prefix` that then calls into `request.GetDisplayUrl()`, we get a null ref.

While in this case it can be argued that the middleware should validate what it is actually doing, in general I don't think a framework method like `request.GetDisplayName()` should ever throw a null reference.