### PR TITLE
Do not check if key is present before removing item in AuthenticationProperties

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Abstractions/AuthenticationProperties.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Abstractions/AuthenticationProperties.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Authentication
             {
                 Items[key] = value;
             }
-            else if (Items.ContainsKey(key))
+            else
             {
                 Items.Remove(key);
             }
@@ -169,9 +169,9 @@ namespace Microsoft.AspNetCore.Authentication
         {
             if (value.HasValue)
             {
-                Items[key] = value.Value.ToString();
+                Items[key] = value.GetValueOrDefault().ToString();
             }
-            else if (Items.ContainsKey(key))
+            else
             {
                 Items.Remove(key);
             }
@@ -201,9 +201,9 @@ namespace Microsoft.AspNetCore.Authentication
         {
             if (value.HasValue)
             {
-                Items[key] = value.Value.ToString(UtcDateTimeFormat, CultureInfo.InvariantCulture);
+                Items[key] = value.GetValueOrDefault().ToString(UtcDateTimeFormat, CultureInfo.InvariantCulture);
             }
-            else if (Items.ContainsKey(key))
+            else
             {
                 Items.Remove(key);
             }

--- a/test/Microsoft.AspNetCore.Authentication.Core.Test/AuthenticationPropertiesTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Core.Test/AuthenticationPropertiesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Xunit;
 
@@ -72,6 +73,10 @@ namespace Microsoft.AspNetCore.Authentication.Core.Test
 
             props.SetString("foo", null);
             Assert.Null(props.GetString("foo"));
+            Assert.Equal(1, props.Items.Count);
+
+            props.SetString("doesntexist", null);
+            Assert.False(props.Items.ContainsKey("doesntexist"));
             Assert.Equal(1, props.Items.Count);
         }
 
@@ -202,6 +207,95 @@ namespace Microsoft.AspNetCore.Authentication.Core.Test
 
             props.Items.Clear();
             Assert.Null(props.AllowRefresh);
+        }
+
+        [Fact]
+        public void SetDateTimeOffset()
+        {
+            var props = new MyAuthenticationProperties();
+
+            props.SetDateTimeOffset("foo", new DateTimeOffset(new DateTime(2018, 03, 19, 12, 34, 56, DateTimeKind.Utc)));
+            Assert.Equal("Mon, 19 Mar 2018 12:34:56 GMT", props.Items["foo"]);
+
+            props.SetDateTimeOffset("foo", null);
+            Assert.False(props.Items.ContainsKey("foo"));
+
+            props.SetDateTimeOffset("doesnotexist", null);
+            Assert.False(props.Items.ContainsKey("doesnotexist"));
+        }
+
+        [Fact]
+        public void GetDateTimeOffset()
+        {
+            var props = new MyAuthenticationProperties();
+            var dateTimeOffset = new DateTimeOffset(new DateTime(2018, 03, 19, 12, 34, 56, DateTimeKind.Utc));
+
+            props.Items["foo"] = dateTimeOffset.ToString("r", CultureInfo.InvariantCulture);
+            Assert.Equal(dateTimeOffset, props.GetDateTimeOffset("foo"));
+
+            props.Items.Remove("foo");
+            Assert.Null(props.GetDateTimeOffset("foo"));
+
+            props.Items["foo"] = "BAR";
+            Assert.Null(props.GetDateTimeOffset("foo"));
+            Assert.Equal("BAR", props.Items["foo"]);
+        }
+
+        [Fact]
+        public void SetBool()
+        {
+            var props = new MyAuthenticationProperties();
+
+            props.SetBool("foo", true);
+            Assert.Equal(true.ToString(), props.Items["foo"]);
+
+            props.SetBool("foo", false);
+            Assert.Equal(false.ToString(), props.Items["foo"]);
+
+            props.SetBool("foo", null);
+            Assert.False(props.Items.ContainsKey("foo"));
+        }
+
+        [Fact]
+        public void GetBool()
+        {
+            var props = new MyAuthenticationProperties();
+
+            props.Items["foo"] = true.ToString();
+            Assert.True(props.GetBool("foo"));
+
+            props.Items["foo"] = false.ToString();
+            Assert.False(props.GetBool("foo"));
+
+            props.Items["foo"] = null;
+            Assert.Null(props.GetBool("foo"));
+
+            props.Items["foo"] = "BAR";
+            Assert.Null(props.GetBool("foo"));
+            Assert.Equal("BAR", props.Items["foo"]);
+        }
+
+        public class MyAuthenticationProperties : AuthenticationProperties
+        {
+            public new DateTimeOffset? GetDateTimeOffset(string key)
+            {
+                return base.GetDateTimeOffset(key);
+            }
+
+            public new void SetDateTimeOffset(string key, DateTimeOffset? value)
+            {
+                base.SetDateTimeOffset(key, value);
+            }
+
+            public new void SetBool(string key, bool? value)
+            {
+                base.SetBool(key, value);
+            }
+
+            public new bool? GetBool(string key)
+            {
+                return base.GetBool(key);
+            }
         }
     }
 }


### PR DESCRIPTION
* Do not check if key is present before removing item, this eliminates double lookup.
* Use `Nullable<T>.GetValueOrDefault()` instead of `Nullable<T>.Value` when it is known to have a value. See #1063 for more info.
* Add some unit tests.

Eliminating the extra lookup yields the following result:

**Before:**

|                  Method |      Mean |     Error |    StdDev |         Op/s |  Gen 0 | Allocated |
|------------------------ |----------:|----------:|----------:|-------------:|-------:|----------:|
|    NullValue_KeyPresent | 123.84 ns | 2.1405 ns | 1.8975 ns |  8,074,763.9 | 0.0036 |     328 B |
| NullValue_KeyNotPresent |  41.63 ns | 0.5963 ns | 0.5577 ns | 24,022,181.2 | 0.0021 |     192 B |

**After:**

|                  Method |      Mean |     Error |    StdDev |         Op/s |  Gen 0 | Allocated |
|------------------------ |----------:|----------:|----------:|-------------:|-------:|----------:|
|    NullValue_KeyPresent | 107.04 ns | 0.9192 ns | 0.8598 ns |  9,342,589.5 | 0.0038 |     328 B |
| NullValue_KeyNotPresent |  39.53 ns | 0.5507 ns | 0.4882 ns | 25,300,109.1 | 0.0021 |     192 B |

Benchmark is available [here](https://gist.github.com/drieseng/96ad8c2680b3ac5b84b6fc2ac0bae100).